### PR TITLE
[FEAT] http patch 메서드를 사용하기 위한 설정 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     runtimeOnly 'com.h2database:h2'
 
+    // for undefined value in json
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
+
     // open feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
 

--- a/src/main/java/org/crops/fitserver/domain/file/constant/FileDomain.java
+++ b/src/main/java/org/crops/fitserver/domain/file/constant/FileDomain.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum FileDomain {
+  PROFILE_DEFAULT_IMAGE("/profile/default", false),
   PROFILE_IMAGE("/profile", false),
   PORTFOLIO("/portfolio", false),
   CHAT("/chat", true);

--- a/src/main/java/org/crops/fitserver/domain/file/service/FileService.java
+++ b/src/main/java/org/crops/fitserver/domain/file/service/FileService.java
@@ -7,5 +7,7 @@ public interface FileService {
 
   PreSignedUrlDto generatePreSignedUrl(String fileName, FileDomain fileDomain);
 
+  boolean isUploaded(String fileName);
+
   void deleteFile(String fileKey);
 }

--- a/src/main/java/org/crops/fitserver/domain/file/service/S3FileServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/file/service/S3FileServiceImpl.java
@@ -8,6 +8,7 @@ import org.crops.fitserver.domain.file.dto.PreSignedUrlDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -47,6 +48,16 @@ public class S3FileServiceImpl implements FileService {
   @Override
   public void deleteFile(String fileKey) {
     s3Client.deleteObject(builder -> builder.bucket(bucket).key(fileKey));
+  }
+
+  @Override
+  public boolean isUploaded(String fileName) {
+    try {
+      s3Client.headObject(builder -> builder.bucket(bucket).key(fileName));
+    } catch (NoSuchKeyException e) {
+      return false;
+    }
+    return true;
   }
 
   private static String createFileKey(String fileName, String directory, boolean isTemporary) {

--- a/src/main/java/org/crops/fitserver/domain/skillset/controller/SkillSetController.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/controller/SkillSetController.java
@@ -51,12 +51,13 @@ public class SkillSetController {
         .body(skillSetService.createPosition(createPositionRequest));
   }
 
-  @PutMapping("/position/{positionId}")
+  @PatchMapping("/position/{positionId}")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity<PositionDto> updatePosition(@PathVariable Long positionId,
       @Valid @RequestBody UpdatePositionRequest updatePositionRequest) {
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).body(
-        skillSetService.updatePositionDisplayName(positionId, updatePositionRequest.displayName()));
+    return ResponseEntity.status(HttpStatus.OK).body(
+        skillSetService.updatePositionDisplayName(positionId, updatePositionRequest.displayName().get())
+    );
   }
 
   @DeleteMapping("/position/{positionId}")
@@ -76,7 +77,7 @@ public class SkillSetController {
   public ResponseEntity<PositionDto> addSkillToPosition(@PathVariable Long positionId,
       @Valid @RequestBody
       AddSkillListToPositionRequest addSkillListToPositionRequest) {
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).body(
+    return ResponseEntity.status(HttpStatus.OK).body(
         skillSetService.addSkillListToPosition(positionId,
             addSkillListToPositionRequest.skillIds()));
   }
@@ -94,12 +95,12 @@ public class SkillSetController {
         .body(skillSetService.createSkill(createSkillRequest));
   }
 
-  @PutMapping("/skill/{skillId}")
+  @PatchMapping("/skill/{skillId}")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity<SkillDto> updateSkill(@PathVariable Long skillId,
       @Valid @RequestBody UpdateSkillRequest updateSkillRequest) {
-    return ResponseEntity.status(HttpStatus.NO_CONTENT)
-        .body(skillSetService.updateSkillDisplayName(skillId, updateSkillRequest.displayName()));
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(skillSetService.updateSkillDisplayName(skillId, updateSkillRequest.displayName().get()));
   }
 
   @DeleteMapping("/skill/{skillId}")
@@ -113,7 +114,7 @@ public class SkillSetController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   public ResponseEntity<SkillDto> addSkillToPositionList(@PathVariable Long skillId,
       @Valid @RequestBody AddSkillToPositionListRequest addSkillToPositionListRequest) {
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).body(
+    return ResponseEntity.status(HttpStatus.OK).body(
         skillSetService.addSkillToPositionList(skillId,
             addSkillToPositionListRequest.positionIds()));
   }

--- a/src/main/java/org/crops/fitserver/domain/skillset/controller/SkillSetController.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/controller/SkillSetController.java
@@ -56,7 +56,7 @@ public class SkillSetController {
   public ResponseEntity<PositionDto> updatePosition(@PathVariable Long positionId,
       @Valid @RequestBody UpdatePositionRequest updatePositionRequest) {
     return ResponseEntity.status(HttpStatus.OK).body(
-        skillSetService.updatePositionDisplayName(positionId, updatePositionRequest.displayName().get())
+        skillSetService.updatePositionDisplayName(positionId, updatePositionRequest)
     );
   }
 

--- a/src/main/java/org/crops/fitserver/domain/skillset/domain/Position.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/domain/Position.java
@@ -41,8 +41,15 @@ public class Position extends BaseTimeEntity {
   @Column(nullable = false)
   private String displayName;
 
+  @Column(nullable = false)
+  private String imageUrl;
+
   public void updateDisplayName(String displayName) {
     this.displayName = displayName;
+  }
+
+  public void updateImageUrl(String imageUrl) {
+    this.imageUrl = imageUrl;
   }
 
   public void addSkill(Skill skill) {

--- a/src/main/java/org/crops/fitserver/domain/skillset/dto/request/CreatePositionRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/dto/request/CreatePositionRequest.java
@@ -7,6 +7,6 @@ import lombok.Builder;
 @Builder
 public record CreatePositionRequest(
     @NotBlank String displayName,
-    List<Long> skillIds) {
+    List<Long> skillIds, @NotBlank String imageUrl) {
 
 }

--- a/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdatePositionRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdatePositionRequest.java
@@ -1,6 +1,7 @@
 package org.crops.fitserver.domain.skillset.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import org.openapitools.jackson.nullable.JsonNullable;
 
-public record UpdatePositionRequest (@NotBlank String displayName) {
+public record UpdatePositionRequest (JsonNullable<@NotBlank String> displayName) {
 }

--- a/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdatePositionRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdatePositionRequest.java
@@ -1,7 +1,10 @@
 package org.crops.fitserver.domain.skillset.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import org.openapitools.jackson.nullable.JsonNullable;
 
-public record UpdatePositionRequest (JsonNullable<@NotBlank String> displayName) {
+@Builder
+public record UpdatePositionRequest (JsonNullable<@NotBlank String> displayName, JsonNullable<@NotBlank String> imageUrl) {
 }

--- a/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdateSkillRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/dto/request/UpdateSkillRequest.java
@@ -1,7 +1,8 @@
 package org.crops.fitserver.domain.skillset.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import org.openapitools.jackson.nullable.JsonNullable;
 
-public record UpdateSkillRequest (@NotBlank String displayName){
+public record UpdateSkillRequest(JsonNullable<@NotBlank String> displayName) {
 
 }

--- a/src/main/java/org/crops/fitserver/domain/skillset/service/SkillSetService.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/service/SkillSetService.java
@@ -5,6 +5,7 @@ import org.crops.fitserver.domain.skillset.dto.PositionDto;
 import org.crops.fitserver.domain.skillset.dto.SkillDto;
 import org.crops.fitserver.domain.skillset.dto.request.CreatePositionRequest;
 import org.crops.fitserver.domain.skillset.dto.request.CreateSkillRequest;
+import org.crops.fitserver.domain.skillset.dto.request.UpdatePositionRequest;
 
 public interface SkillSetService {
 
@@ -23,7 +24,7 @@ public interface SkillSetService {
 
   SkillDto addSkillToPositionList(Long SkillId, List<Long> positionIds);
 
-  PositionDto updatePositionDisplayName(Long positionId, String displayName);
+  PositionDto updatePositionDisplayName(Long positionId, UpdatePositionRequest request);
 
   PositionDto addSkillListToPosition(Long positionId, List<Long> skillIds);
 

--- a/src/main/java/org/crops/fitserver/domain/skillset/service/SkillSetServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/service/SkillSetServiceImpl.java
@@ -16,7 +16,6 @@ import org.crops.fitserver.domain.skillset.repository.PositionRepository;
 import org.crops.fitserver.domain.skillset.repository.SkillRepository;
 import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
-import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -51,7 +50,7 @@ class SkillSetServiceImpl implements SkillSetService {
   @Override
   @Transactional
   public PositionDto createPosition(CreatePositionRequest request) {
-    validatePositionDisplayName(request.displayName());
+    handleDuplicatedDisplayName(request.displayName());
     validateImageUrl(request.imageUrl());
 
     var position = Position.builder().displayName(request.displayName())
@@ -111,7 +110,7 @@ class SkillSetServiceImpl implements SkillSetService {
   @Transactional
   public PositionDto updatePositionDisplayName(Long positionId, UpdatePositionRequest request) {
     if(request.displayName().isPresent()) {
-      validatePositionDisplayName(request.displayName().get());
+      handleDuplicatedDisplayName(request.displayName().get());
     };
     if(request.imageUrl().isPresent()){
       validateImageUrl(request.imageUrl().get());
@@ -149,7 +148,7 @@ class SkillSetServiceImpl implements SkillSetService {
     positionRepository.deleteById(positionId);
   }
 
-  private void validatePositionDisplayName(String displayName) {
+  private void handleDuplicatedDisplayName(String displayName) {
     if (positionRepository.findByDisplayName(displayName).isPresent()) {
       throw new BusinessException(ErrorCode.DUPLICATED_RESOURCE_EXCEPTION);
     }

--- a/src/main/java/org/crops/fitserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/crops/fitserver/domain/user/controller/UserController.java
@@ -16,7 +16,7 @@ import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,7 +37,7 @@ public class UserController {
     return ResponseEntity.ok(userFacade.getUserWithInfo(userId));
   }
 
-  @PutMapping()
+  @PatchMapping()
   public ResponseEntity<UserInfoDto> updateUser(
       @CurrentUserId Long userId,
       @Valid @RequestBody UpdateUserRequest updateUserRequest) {

--- a/src/main/java/org/crops/fitserver/domain/user/domain/User.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/User.java
@@ -75,34 +75,13 @@ public class User extends BaseTimeEntity {
     this.userInfo = UserInfo.from(this);
   }
 
-  public User withProfileImageUrl(JsonNullable<String> profileImageUrl) {
-    if (profileImageUrl.isPresent()) {
-      withProfileImageUrl(profileImageUrl.get());
-    }
-    return this;
-  }
-
   public User withProfileImageUrl(String profileImageUrl) {
     this.profileImageUrl = profileImageUrl;
     return this;
   }
 
-  public User withUsername(JsonNullable<String> username) {
-    if (username.isPresent()) {
-      withUsername(username.get());
-    }
-    return this;
-  }
-
   public User withUsername(String username) {
     this.username = username;
-    return this;
-  }
-
-  public User withNickname(JsonNullable<String> nickname) {
-    if (nickname.isPresent()) {
-      withNickname(nickname.get());
-    }
     return this;
   }
 
@@ -114,13 +93,6 @@ public class User extends BaseTimeEntity {
     return this;
   }
 
-  public User withPhoneNumber(JsonNullable<String> phoneNumber) {
-    if (phoneNumber.isPresent()) {
-      withPhoneNumber(phoneNumber.get());
-    }
-    return this;
-  }
-
   public User withPhoneNumber(String phoneNumber) {
     if (StringUtils.isBlank(phoneNumber)) {
       throw new IllegalArgumentException("phoneNumber cannot be null");
@@ -129,22 +101,8 @@ public class User extends BaseTimeEntity {
     return this;
   }
 
-  public User withIsOpenPhoneNum(JsonNullable<Boolean> isOpenPhoneNum) {
-    if (isOpenPhoneNum.isPresent()) {
-      withIsOpenPhoneNum(isOpenPhoneNum.get());
-    }
-    return this;
-  }
-
   public User withIsOpenPhoneNum(boolean isOpenPhoneNum) {
     this.isOpenPhoneNum = isOpenPhoneNum;
-    return this;
-  }
-
-  public User withEmail(JsonNullable<String> email) {
-    if (email.isPresent()) {
-      withEmail(email.get());
-    }
     return this;
   }
 

--- a/src/main/java/org/crops/fitserver/domain/user/domain/User.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/User.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 @Entity
 @Getter
@@ -74,8 +75,22 @@ public class User extends BaseTimeEntity {
     this.userInfo = UserInfo.from(this);
   }
 
+  public User withProfileImageUrl(JsonNullable<String> profileImageUrl) {
+    if (profileImageUrl.isPresent()) {
+      withProfileImageUrl(profileImageUrl.get());
+    }
+    return this;
+  }
+
   public User withProfileImageUrl(String profileImageUrl) {
     this.profileImageUrl = profileImageUrl;
+    return this;
+  }
+
+  public User withUsername(JsonNullable<String> username) {
+    if (username.isPresent()) {
+      withUsername(username.get());
+    }
     return this;
   }
 
@@ -84,19 +99,40 @@ public class User extends BaseTimeEntity {
     return this;
   }
 
+  public User withNickname(JsonNullable<String> nickname) {
+    if (nickname.isPresent()) {
+      withNickname(nickname.get());
+    }
+    return this;
+  }
+
   public User withNickname(String nickname) {
-    if (StringUtils.isNotBlank(this.nickname) && StringUtils.isBlank(nickname)) {
+    if (StringUtils.isBlank(nickname)) {
       throw new IllegalArgumentException("nickname cannot be null");
     }
     this.nickname = nickname;
     return this;
   }
 
+  public User withPhoneNumber(JsonNullable<String> phoneNumber) {
+    if (phoneNumber.isPresent()) {
+      withPhoneNumber(phoneNumber.get());
+    }
+    return this;
+  }
+
   public User withPhoneNumber(String phoneNumber) {
-    if (StringUtils.isNotBlank(this.phoneNumber) && StringUtils.isBlank(phoneNumber)) {
+    if (StringUtils.isBlank(phoneNumber)) {
       throw new IllegalArgumentException("phoneNumber cannot be null");
     }
     this.phoneNumber = phoneNumber;
+    return this;
+  }
+
+  public User withIsOpenPhoneNum(JsonNullable<Boolean> isOpenPhoneNum) {
+    if (isOpenPhoneNum.isPresent()) {
+      withIsOpenPhoneNum(isOpenPhoneNum.get());
+    }
     return this;
   }
 
@@ -105,8 +141,15 @@ public class User extends BaseTimeEntity {
     return this;
   }
 
+  public User withEmail(JsonNullable<String> email) {
+    if (email.isPresent()) {
+      withEmail(email.get());
+    }
+    return this;
+  }
+
   public User withEmail(String email) {
-    if (StringUtils.isNotBlank(this.email) && StringUtils.isBlank(email)) {
+    if (StringUtils.isBlank(email)) {
       throw new IllegalArgumentException("email cannot be null");
     }
     this.email = email;

--- a/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
@@ -28,6 +28,7 @@ import org.crops.fitserver.domain.user.constant.BackgroundStatus;
 import org.crops.fitserver.domain.user.constant.UserInfoStatus;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.util.CollectionUtils;
 
 @Entity(name = "user_info")
@@ -58,7 +59,7 @@ public class UserInfo {
   private String linkJson;
 
   @Enumerated(value = EnumType.STRING)
-  @Column(length = 10)
+  @Column(length = 20)
   private BackgroundStatus backgroundStatus;
 
   private String career;
@@ -105,55 +106,104 @@ public class UserInfo {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
   }
 
+  public UserInfo withPortfolioUrl(JsonNullable<String> portfolioUrl) {
+    if (portfolioUrl.isPresent()) {
+      withPortfolioUrl(portfolioUrl.get());
+    }
+    return this;
+  }
+
 
   public UserInfo withPortfolioUrl(String portfolioUrl) {
     this.portfolioUrl = portfolioUrl;
     return this;
   }
 
+  public UserInfo withProjectCount(JsonNullable<Integer> projectCount) {
+    if (projectCount.isPresent()) {
+      withProjectCount(projectCount.get());
+    }
+    return this;
+  }
+
   public UserInfo withProjectCount(Integer projectCount) {
-    if (this.projectCount != null && projectCount == null) {
+    if (projectCount == null) {
       throw new IllegalArgumentException("projectCount cannot be null");
     }
     this.projectCount = projectCount;
     return this;
   }
 
+  public UserInfo withActivityHour(JsonNullable<Integer> activityHour) {
+    if (activityHour.isPresent()) {
+      withActivityHour(activityHour.get());
+    }
+    return this;
+  }
+
   public UserInfo withActivityHour(Integer activityHour) {
-    if (this.activityHour != null && activityHour == null) {
+    if (activityHour == null) {
       throw new IllegalArgumentException("activityHour cannot be null");
     }
     this.activityHour = activityHour;
     return this;
   }
 
+  public UserInfo withIntroduce(JsonNullable<String> introduce) {
+    if (introduce.isPresent()) {
+      withIntroduce(introduce.get());
+    }
+    return this;
+  }
+
   public UserInfo withIntroduce(String introduce) {
-    if (StringUtils.isNotBlank(this.introduce) && StringUtils.isBlank(introduce)) {
+    if (StringUtils.isBlank(introduce)) {
       throw new IllegalArgumentException("introduce cannot be null");
     }
     this.introduce = introduce;
     return this;
   }
 
+  public UserInfo withLinkJson(JsonNullable<String> linkJson) {
+    if (linkJson.isPresent()) {
+      withLinkJson(linkJson.get());
+    }
+    return this;
+  }
+
   public UserInfo withLinkJson(String linkJson) {
-    if (StringUtils.isNotBlank(this.linkJson) && StringUtils.isBlank(linkJson)) {
+    if (StringUtils.isBlank(linkJson)) {
       throw new IllegalArgumentException("linkJson cannot be null");
     }
     this.linkJson = linkJson;
     return this;
   }
 
+  public UserInfo withBackground(JsonNullable<BackgroundStatus> backgroundStatus,
+      JsonNullable<String> backgroundText) {
+    if (!backgroundStatus.isPresent() && !backgroundText.isPresent()) {
+      return this;
+    }
+
+    withBackground(
+        backgroundStatus.orElse(this.backgroundStatus),
+        backgroundStatus.get() == this.backgroundStatus
+            ? backgroundText.orElse(getBackgroundText())
+            : null);
+
+    return this;
+  }
+
+  private String getBackgroundText() {
+    return this.backgroundStatus.getBackgroundType() == BackgroundStatus.BackgroundType.CAREER
+        ? this.career : this.education;
+  }
+
   public UserInfo withBackground(BackgroundStatus backgroundStatus, String backgroundText) {
-    if (this.backgroundStatus != null && backgroundStatus == null) {
+    if (backgroundStatus == null) {
       throw new IllegalArgumentException("backgroundStatus cannot be null");
     }
     this.backgroundStatus = backgroundStatus;
-
-    if (this.backgroundStatus == null) {
-      this.career = null;
-      this.education = null;
-      return this;
-    }
 
     switch (backgroundStatus.getBackgroundType()) {
       case CAREER -> {
@@ -168,14 +218,20 @@ public class UserInfo {
     return this;
   }
 
+  public UserInfo withIsOpenProfile(JsonNullable<Boolean> isOpenProfile) {
+    if (isOpenProfile.isPresent()) {
+      withIsOpenProfile(isOpenProfile.get());
+    }
+    return this;
+  }
+
   public UserInfo withIsOpenProfile(boolean isOpenProfile) {
     this.isOpenProfile = isOpenProfile;
     return this;
   }
 
-
   public UserInfo withPosition(Position position) {
-    if (this.position != null && position == null) {
+    if (position == null) {
       throw new IllegalArgumentException("position cannot be null");
     }
     this.position = position;
@@ -183,7 +239,7 @@ public class UserInfo {
   }
 
   public UserInfo withRegion(Region region) {
-    if (this.region != null && region == null) {
+    if (region == null) {
       throw new IllegalArgumentException("region cannot be null");
     }
     this.region = region;

--- a/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
@@ -106,23 +106,9 @@ public class UserInfo {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
   }
 
-  public UserInfo withPortfolioUrl(JsonNullable<String> portfolioUrl) {
-    if (portfolioUrl.isPresent()) {
-      withPortfolioUrl(portfolioUrl.get());
-    }
-    return this;
-  }
-
 
   public UserInfo withPortfolioUrl(String portfolioUrl) {
     this.portfolioUrl = portfolioUrl;
-    return this;
-  }
-
-  public UserInfo withProjectCount(JsonNullable<Integer> projectCount) {
-    if (projectCount.isPresent()) {
-      withProjectCount(projectCount.get());
-    }
     return this;
   }
 
@@ -134,13 +120,6 @@ public class UserInfo {
     return this;
   }
 
-  public UserInfo withActivityHour(JsonNullable<Integer> activityHour) {
-    if (activityHour.isPresent()) {
-      withActivityHour(activityHour.get());
-    }
-    return this;
-  }
-
   public UserInfo withActivityHour(Integer activityHour) {
     if (activityHour == null) {
       throw new IllegalArgumentException("activityHour cannot be null");
@@ -149,25 +128,11 @@ public class UserInfo {
     return this;
   }
 
-  public UserInfo withIntroduce(JsonNullable<String> introduce) {
-    if (introduce.isPresent()) {
-      withIntroduce(introduce.get());
-    }
-    return this;
-  }
-
   public UserInfo withIntroduce(String introduce) {
     if (StringUtils.isBlank(introduce)) {
       throw new IllegalArgumentException("introduce cannot be null");
     }
     this.introduce = introduce;
-    return this;
-  }
-
-  public UserInfo withLinkJson(JsonNullable<String> linkJson) {
-    if (linkJson.isPresent()) {
-      withLinkJson(linkJson.get());
-    }
     return this;
   }
 
@@ -214,13 +179,6 @@ public class UserInfo {
         this.career = null;
         this.education = backgroundText;
       }
-    }
-    return this;
-  }
-
-  public UserInfo withIsOpenProfile(JsonNullable<Boolean> isOpenProfile) {
-    if (isOpenProfile.isPresent()) {
-      withIsOpenProfile(isOpenProfile.get());
     }
     return this;
   }

--- a/src/main/java/org/crops/fitserver/domain/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/user/dto/request/UpdateUserRequest.java
@@ -3,65 +3,156 @@ package org.crops.fitserver.domain.user.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.crops.fitserver.domain.user.constant.BackgroundStatus;
 import org.crops.fitserver.domain.user.domain.Link;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateUserRequest {
 
-  private String profileImageUrl;
+  private JsonNullable<String> profileImageUrl;
 
-  private String username;
+  private JsonNullable<String> username;
 
-  private String nickname;
+  private JsonNullable<String> nickname;
 
-  private String phoneNumber;
+  private JsonNullable<String> phoneNumber;
 
   @JsonProperty("isOpenPhoneNum")
-  @NotNull
-  private Boolean isOpenPhoneNum;
+  private JsonNullable<@NotNull Boolean> isOpenPhoneNum;
 
-  private String email;
+  private JsonNullable<String> email;
 
-  private BackgroundStatus backgroundStatus;
-  private String backgroundText;
+  private JsonNullable<BackgroundStatus> backgroundStatus;
+  private JsonNullable<String> backgroundText;
 
-  private String portfolioUrl;
+  private JsonNullable<String> portfolioUrl;
 
-  private Integer projectCount;
+  private JsonNullable<Integer> projectCount;
 
-  private Integer activityHour;
+  private JsonNullable<Integer> activityHour;
 
-  private String introduce;
+  private JsonNullable<String> introduce;
 
-  private List<Link> linkList;
+  private JsonNullable<List<Link>> linkList;
 
   @JsonProperty("isOpenProfile")
-  @NotNull
-  private Boolean isOpenProfile;
+  private JsonNullable<@NotNull Boolean> isOpenProfile;
 
-  private Long positionId;
+  private JsonNullable<Long> positionId;
 
-  private Long regionId;
+  private JsonNullable<Long> regionId;
 
-  private List<Long> skillIdList;
+  private JsonNullable<List<Long>> skillIdList;
 
-  public Boolean getIsOpenPhoneNum() {
+  public JsonNullable<Boolean> getIsOpenPhoneNum() {
     return isOpenPhoneNum;
   }
 
-  public Boolean getIsOpenProfile() {
+  public void setIsOpenPhoneNum(Boolean isOpenPhoneNum) {
+    this.isOpenPhoneNum = JsonNullable.of(isOpenPhoneNum);
+  }
+
+  public JsonNullable<Boolean> getIsOpenProfile() {
     return isOpenProfile;
   }
 
-  public void setIsOpenPhoneNum(Boolean isOpenPhoneNum) {
-    this.isOpenPhoneNum = isOpenPhoneNum;
+  public void setIsOpenProfile(Boolean isOpenProfile) {
+    this.isOpenProfile = JsonNullable.of(isOpenProfile);
   }
 
-  public void setIsOpenProfile(Boolean isOpenProfile) {
-    this.isOpenProfile = isOpenProfile;
+  public static class UpdateUserRequestBuilder {
+
+    public UpdateUserRequestBuilder profileImageUrl(String profileImageUrl) {
+      this.profileImageUrl = JsonNullable.of(profileImageUrl);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder username(String username) {
+      this.username = JsonNullable.of(username);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder nickname(String nickname) {
+      this.nickname = JsonNullable.of(nickname);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder phoneNumber(String phoneNumber) {
+      this.phoneNumber = JsonNullable.of(phoneNumber);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder email(String email) {
+      this.email = JsonNullable.of(email);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder backgroundStatus(BackgroundStatus backgroundStatus) {
+      this.backgroundStatus = JsonNullable.of(backgroundStatus);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder backgroundText(String backgroundText) {
+      this.backgroundText = JsonNullable.of(backgroundText);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder portfolioUrl(String portfolioUrl) {
+      this.portfolioUrl = JsonNullable.of(portfolioUrl);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder projectCount(Integer projectCount) {
+      this.projectCount = JsonNullable.of(projectCount);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder activityHour(Integer activityHour) {
+      this.activityHour = JsonNullable.of(activityHour);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder introduce(String introduce) {
+      this.introduce = JsonNullable.of(introduce);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder linkList(List<Link> linkList) {
+      this.linkList = JsonNullable.of(linkList);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder positionId(Long positionId) {
+      this.positionId = JsonNullable.of(positionId);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder regionId(Long regionId) {
+      this.regionId = JsonNullable.of(regionId);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder skillIdList(List<Long> skillIdList) {
+      this.skillIdList = JsonNullable.of(skillIdList);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder isOpenPhoneNum(Boolean isOpenPhoneNum) {
+      this.isOpenPhoneNum = JsonNullable.of(isOpenPhoneNum);
+      return this;
+    }
+
+    public UpdateUserRequestBuilder isOpenProfile(Boolean isOpenProfile) {
+      this.isOpenProfile = JsonNullable.of(isOpenProfile);
+      return this;
+    }
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/user/service/UserServiceImpl.java
@@ -4,12 +4,15 @@ import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.crops.fitserver.domain.region.domain.Region;
 import org.crops.fitserver.domain.region.repository.RegionRepository;
+import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.domain.Skill;
 import org.crops.fitserver.domain.skillset.repository.PositionRepository;
 import org.crops.fitserver.domain.skillset.repository.SkillRepository;
 import org.crops.fitserver.domain.user.domain.Link;
 import org.crops.fitserver.domain.user.domain.User;
+import org.crops.fitserver.domain.user.domain.UserInfoSkill;
 import org.crops.fitserver.domain.user.domain.UserPolicyAgreement;
 import org.crops.fitserver.domain.user.dto.PolicyAgreementDto;
 import org.crops.fitserver.domain.user.dto.request.UpdateUserRequest;
@@ -17,6 +20,7 @@ import org.crops.fitserver.domain.user.repository.UserPolicyAgreementRepository;
 import org.crops.fitserver.domain.user.repository.UserRepository;
 import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -41,41 +45,68 @@ public class UserServiceImpl implements UserService {
   public User updateUserWithInfo(Long userId, UpdateUserRequest updateUserRequest) {
     var user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
-    var position = updateUserRequest.getPositionId() != null ?
-        positionRepository.findById(updateUserRequest.getPositionId())
-            .orElseThrow(() -> new BusinessException(
-                ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION))
-        : null;
-    var region = updateUserRequest.getRegionId() != null ?
-        regionRepository.findById(updateUserRequest.getRegionId())
-            .orElseThrow(() -> new BusinessException(
-                ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION))
-        : null;
-    var skillList = !CollectionUtils.isEmpty(updateUserRequest.getSkillIdList()) ?
-        skillRepository.findAllById(updateUserRequest.getSkillIdList())
-        : new ArrayList<Skill>();
 
     user = user
-        .withProfileImageUrl(updateUserRequest.getProfileImageUrl())
-        .withUsername(updateUserRequest.getUsername())
-        .withNickname(updateUserRequest.getNickname())
-        .withPhoneNumber(updateUserRequest.getPhoneNumber())
-        .withIsOpenPhoneNum(updateUserRequest.getIsOpenPhoneNum())
-        .withEmail(updateUserRequest.getEmail());
+        .withProfileImageUrl(
+            updateUserRequest.getProfileImageUrl().orElse(user.getProfileImageUrl()))
+        .withUsername(updateUserRequest.getUsername().orElse(user.getUsername()))
+        .withNickname(updateUserRequest.getNickname().orElse(user.getNickname()))
+        .withPhoneNumber(updateUserRequest.getPhoneNumber().orElse(user.getPhoneNumber()))
+        .withIsOpenPhoneNum(updateUserRequest.getIsOpenPhoneNum().orElse(user.isOpenPhoneNum()))
+        .withEmail(updateUserRequest.getEmail().orElse(user.getEmail()));
 
     user.getUserInfo()
         .withBackground(updateUserRequest.getBackgroundStatus(),
             updateUserRequest.getBackgroundText())
-        .withPortfolioUrl(updateUserRequest.getPortfolioUrl())
-        .withProjectCount(updateUserRequest.getProjectCount())
-        .withActivityHour(updateUserRequest.getActivityHour())
-        .withIntroduce(updateUserRequest.getIntroduce())
-        .withLinkJson(Link.parseToJson(updateUserRequest.getLinkList()))
-        .withIsOpenProfile(updateUserRequest.getIsOpenProfile())
-        .withPosition(position)
-        .withRegion(region)
-        .withSkills(skillList);
+        .withPortfolioUrl(
+            updateUserRequest.getPortfolioUrl().orElse(user.getUserInfo().getPortfolioUrl()))
+        .withProjectCount(
+            updateUserRequest.getProjectCount().orElse(user.getUserInfo().getProjectCount()))
+        .withActivityHour(
+            updateUserRequest.getActivityHour().orElse(user.getUserInfo().getActivityHour()))
+        .withIntroduce(updateUserRequest.getIntroduce().orElse(user.getUserInfo().getIntroduce()))
+        .withLinkJson(updateUserRequest.getLinkList().isPresent() ? Link.parseToJson(
+            updateUserRequest.getLinkList().orElse(List.of())) : user.getUserInfo().getLinkJson())
+        .withIsOpenProfile(
+            updateUserRequest.getIsOpenProfile().orElse(user.getUserInfo().isOpenProfile()))
+        .withPosition(getNewPosition(updateUserRequest.getPositionId(), user))
+        .withRegion(getNewRegion(updateUserRequest.getRegionId(), user))
+        .withSkills(getNewSkillList(updateUserRequest.getSkillIdList(), user));
+
+    user = userRepository.save(user);
     return user;
+  }
+
+  private Position getNewPosition(JsonNullable<Long> positionId, User user) {
+    if (!positionId.isPresent()) {
+      return user.getUserInfo().getPosition();
+    }
+    if (positionId.get() == null) {
+      return null;
+    }
+    return positionRepository.findById(positionId.get()).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
+  }
+
+  private Region getNewRegion(JsonNullable<Long> regionId, User user) {
+    if (!regionId.isPresent()) {
+      return user.getUserInfo().getRegion();
+    }
+    if (regionId.get() == null) {
+      return null;
+    }
+    return regionRepository.findById(regionId.get()).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
+  }
+
+  private List<Skill> getNewSkillList(JsonNullable<List<Long>> skillIdList, User user) {
+    if (!skillIdList.isPresent()) {
+      return user.getUserInfo().getUserInfoSkills().stream().map(UserInfoSkill::getSkill).toList();
+    }
+    if (CollectionUtils.isEmpty(skillIdList.get())) {
+      return new ArrayList<>();
+    }
+    return skillRepository.findAllById(skillIdList.get());
   }
 
   public List<UserPolicyAgreement> getPolicyAgreementList(Long userId) {

--- a/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
@@ -1,0 +1,31 @@
+package org.crops.fitserver.global.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class ObjectMapperConfig {
+
+  @Bean
+  @Primary
+  public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+    return builder -> {
+      builder.serializationInclusion(JsonInclude.Include.ALWAYS);
+      builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+      builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+      builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      builder.modules(jsonNullableModule());
+    };
+  }
+
+  @Bean
+  public JsonNullableModule jsonNullableModule() {
+    return new JsonNullableModule();
+  }
+}

--- a/src/test/java/org/crops/fitserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/auth/controller/AuthControllerTest.java
@@ -16,7 +16,7 @@ import com.epages.restdocs.apispec.Schema;
 import org.crops.fitserver.domain.auth.facade.AuthFacade;
 import org.crops.fitserver.domain.auth.facade.dto.SocialLoginPageResponse;
 import org.crops.fitserver.domain.auth.facade.dto.TokenResponse;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.user.domain.SocialPlatform;
 import org.crops.fitserver.global.jwt.TokenCollection;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +32,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(AuthController.class)
 @DisplayName("[Auth][Controller] AuthController Test")
-class AuthControllerTest extends MockMvcDocsTest {
+class AuthControllerTest extends MockMvcDocs {
 
   @MockBean
   AuthFacade authFacade;

--- a/src/test/java/org/crops/fitserver/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/file/controller/FileControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.EnumFields;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.file.constant.FileDomain;
 import org.crops.fitserver.domain.file.dto.PreSignedUrlDto;
 import org.crops.fitserver.domain.file.dto.request.GeneratePreSignedUrlRequest;
@@ -24,7 +24,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(FileController.class)
-class FileControllerTest extends MockMvcDocsTest {
+class FileControllerTest extends MockMvcDocs {
 
   @MockBean
   FileService fileService;

--- a/src/test/java/org/crops/fitserver/domain/region/controller/RegionControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/region/controller/RegionControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.region.dto.RegionDto;
 import org.crops.fitserver.domain.region.dto.request.CreateRegionRequest;
 import org.crops.fitserver.domain.region.dto.request.UpdateRegionRequest;
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(RegionController.class)
-class RegionControllerTest extends MockMvcDocsTest {
+class RegionControllerTest extends MockMvcDocs {
 
   @MockBean
   RegionService regionService;

--- a/src/test/java/org/crops/fitserver/domain/school/controller/SchoolControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/school/controller/SchoolControllerTest.java
@@ -11,7 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.EnumFields;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.util.List;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.school.constant.SchoolType;
 import org.crops.fitserver.domain.school.dto.SchoolDto;
 import org.crops.fitserver.domain.school.service.SchoolService;
@@ -21,7 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(SchoolController.class)
-class SchoolControllerTest extends MockMvcDocsTest {
+class SchoolControllerTest extends MockMvcDocs {
 
   @MockBean
   SchoolService schoolService;

--- a/src/test/java/org/crops/fitserver/domain/skillset/controller/SkillSetControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/skillset/controller/SkillSetControllerTest.java
@@ -9,14 +9,12 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
-import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.skillset.dto.PositionDto;
 import org.crops.fitserver.domain.skillset.dto.SkillDto;
 import org.crops.fitserver.domain.skillset.dto.request.AddSkillListToPositionRequest;
@@ -28,6 +26,7 @@ import org.crops.fitserver.domain.skillset.dto.request.UpdateSkillRequest;
 import org.crops.fitserver.domain.skillset.service.SkillSetService;
 import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.junit.jupiter.api.Test;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -92,15 +91,19 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .description("직군 리스트를 조회한다.")
                         .responseSchema(Schema.schema("position-list"))
                         .responseFields(
-                            fieldWithPath("positionList[]").type(JsonFieldType.ARRAY).description("직군 리스트"),
-                            fieldWithPath("positionList[].id").type(JsonFieldType.NUMBER).description("직군 id"),
+                            fieldWithPath("positionList[]").type(JsonFieldType.ARRAY)
+                                .description("직군 리스트"),
+                            fieldWithPath("positionList[].id").type(JsonFieldType.NUMBER)
+                                .description("직군 id"),
                             fieldWithPath("positionList[].displayName").type(JsonFieldType.STRING)
                                 .description("직군 이름"),
                             fieldWithPath("positionList[].skillList").type(JsonFieldType.ARRAY)
                                 .description("직군에 속한 스킬 리스트"),
-                            fieldWithPath("positionList[].skillList[].id").type(JsonFieldType.NUMBER)
+                            fieldWithPath("positionList[].skillList[].id").type(
+                                    JsonFieldType.NUMBER)
                                 .description("스킬 id"),
-                            fieldWithPath("positionList[].skillList[].displayName").type(JsonFieldType.STRING)
+                            fieldWithPath("positionList[].skillList[].displayName").type(
+                                    JsonFieldType.STRING)
                                 .description("스킬 이름")
                         )
                         .build()
@@ -114,7 +117,7 @@ class SkillSetControllerTest extends MockMvcDocs {
     //given
     var url = "/v1/skill-set/position";
     CreatePositionRequest createPositionRequest = CreatePositionRequest.builder()
-        .displayName("test").build();
+        .displayName("test").imageUrl("test").build();
     given(skillSetService.createPosition(any())).willThrow(
         new BusinessException(ErrorCode.DUPLICATED_RESOURCE_EXCEPTION)
     );
@@ -138,6 +141,8 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .requestFields(
                             fieldWithPath("displayName").type(JsonFieldType.STRING)
                                 .description("직군 이름"),
+                            fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                .description("직군 이미지 url(profileDefault)"),
                             fieldWithPath("skillIds").type(JsonFieldType.ARRAY)
                                 .description("직군에 속한 스킬 리스트").optional()
                         )
@@ -158,7 +163,7 @@ class SkillSetControllerTest extends MockMvcDocs {
     //given
     var url = "/v1/skill-set/position";
     CreatePositionRequest createPositionRequest = CreatePositionRequest.builder()
-        .displayName("test").build();
+        .displayName("test").imageUrl("test").build();
     given(skillSetService.createPosition(any())).willReturn(PositionDto.builder()
         .id(1L)
         .displayName("test")
@@ -183,6 +188,8 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .requestFields(
                             fieldWithPath("displayName").type(JsonFieldType.STRING)
                                 .description("직군 이름"),
+                            fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                .description("직군 이미지 url(profileDefault)"),
                             fieldWithPath("skillIds").description("직군에 속한 스킬 리스트").optional()
                         )
                         .responseSchema(Schema.schema("position"))
@@ -205,6 +212,7 @@ class SkillSetControllerTest extends MockMvcDocs {
     var url = "/v1/skill-set/position";
     CreatePositionRequest createPositionRequest = CreatePositionRequest.builder()
         .displayName("test")
+        .imageUrl("test")
         .skillIds(List.of(1L, 2L))
         .build();
     given(skillSetService.createPosition(any())).willThrow(
@@ -230,6 +238,8 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .requestFields(
                             fieldWithPath("displayName").type(JsonFieldType.STRING)
                                 .description("직군 이름"),
+                            fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                .description("직군 이미지 url(profileDefault)"),
                             fieldWithPath("skillIds").type(JsonFieldType.ARRAY)
                                 .description("직군에 속한 스킬 리스트").optional()
                         )
@@ -252,6 +262,7 @@ class SkillSetControllerTest extends MockMvcDocs {
     CreatePositionRequest createPositionRequest = CreatePositionRequest.builder()
         .displayName("test")
         .skillIds(List.of(1L, 2L))
+        .imageUrl("test")
         .build();
     given(skillSetService.createPosition(any())).willReturn(PositionDto.builder()
         .id(1L)
@@ -287,6 +298,8 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .requestFields(
                             fieldWithPath("displayName").type(JsonFieldType.STRING)
                                 .description("직군 이름"),
+                            fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                .description("직군 이미지 url(profileDefault)"),
                             fieldWithPath("skillIds").description("직군에 속한 스킬 리스트").optional()
                         )
                         .responseSchema(Schema.schema("position"))
@@ -311,13 +324,14 @@ class SkillSetControllerTest extends MockMvcDocs {
   public void update_position_displayName_fail_duplicate() throws Exception {
     //given
     var url = "/v1/skill-set/position/{positionId}";
-    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"));
+    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"),
+        JsonNullable.undefined());
     given(skillSetService.updatePositionDisplayName(any(), any())).willThrow(
         new BusinessException(ErrorCode.DUPLICATED_RESOURCE_EXCEPTION)
     );
 
     //when
-    var result = mockMvc.perform(patch(url,1L)
+    var result = mockMvc.perform(patch(url, 1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updatePositionRequest))
     );
@@ -352,14 +366,15 @@ class SkillSetControllerTest extends MockMvcDocs {
   public void update_position_displayName_success() throws Exception {
     //given
     var url = "/v1/skill-set/position/{positionId}";
-    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"));
+    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"),
+        JsonNullable.undefined());
     given(skillSetService.updatePositionDisplayName(any(), any())).willReturn(PositionDto.builder()
         .id(1L)
         .displayName("test")
         .build());
 
     //when
-    var result = mockMvc.perform(patch(url,1L)
+    var result = mockMvc.perform(patch(url, 1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updatePositionRequest))
     );
@@ -455,7 +470,7 @@ class SkillSetControllerTest extends MockMvcDocs {
     var url = "/v1/skill-set/position/{positionId}";
 
     //when
-    var result = mockMvc.perform(delete(url,1L));
+    var result = mockMvc.perform(delete(url, 1L));
 
     //then
     result.andExpect(status().isOk())
@@ -501,8 +516,10 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .description("스킬 리스트를 조회한다.")
                         .responseSchema(Schema.schema("skill-list"))
                         .responseFields(
-                            fieldWithPath("skillList[]").type(JsonFieldType.ARRAY).description("스킬 리스트"),
-                            fieldWithPath("skillList[].id").type(JsonFieldType.NUMBER).description("스킬 id"),
+                            fieldWithPath("skillList[]").type(JsonFieldType.ARRAY)
+                                .description("스킬 리스트"),
+                            fieldWithPath("skillList[].id").type(JsonFieldType.NUMBER)
+                                .description("스킬 id"),
                             fieldWithPath("skillList[].displayName").type(JsonFieldType.STRING)
                                 .description("스킬 이름")
                         )
@@ -541,8 +558,10 @@ class SkillSetControllerTest extends MockMvcDocs {
                         .description("직군에 속한 스킬 리스트를 조회한다.")
                         .responseSchema(Schema.schema("skill-list"))
                         .responseFields(
-                            fieldWithPath("skillList[]").type(JsonFieldType.ARRAY).description("스킬 리스트"),
-                            fieldWithPath("skillList[].id").type(JsonFieldType.NUMBER).description("스킬 id"),
+                            fieldWithPath("skillList[]").type(JsonFieldType.ARRAY)
+                                .description("스킬 리스트"),
+                            fieldWithPath("skillList[].id").type(JsonFieldType.NUMBER)
+                                .description("스킬 id"),
                             fieldWithPath("skillList[].displayName").type(JsonFieldType.STRING)
                                 .description("스킬 이름")
                         )

--- a/src/test/java/org/crops/fitserver/domain/skillset/controller/SkillSetControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/skillset/controller/SkillSetControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.skillset.dto.PositionDto;
 import org.crops.fitserver.domain.skillset.dto.SkillDto;
 import org.crops.fitserver.domain.skillset.dto.request.AddSkillListToPositionRequest;
@@ -29,13 +29,14 @@ import org.crops.fitserver.domain.skillset.service.SkillSetService;
 import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(SkillSetController.class)
-class SkillSetControllerTest extends MockMvcDocsTest {
+class SkillSetControllerTest extends MockMvcDocs {
 
   @MockBean
   SkillSetService skillSetService;
@@ -309,14 +310,14 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void update_position_displayName_fail_duplicate() throws Exception {
     //given
-    var url = "/v1/skill-set/position/1";
-    var updatePositionRequest = new UpdatePositionRequest("test");
+    var url = "/v1/skill-set/position/{positionId}";
+    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"));
     given(skillSetService.updatePositionDisplayName(any(), any())).willThrow(
         new BusinessException(ErrorCode.DUPLICATED_RESOURCE_EXCEPTION)
     );
 
     //when
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url,1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updatePositionRequest))
     );
@@ -350,21 +351,21 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void update_position_displayName_success() throws Exception {
     //given
-    var url = "/v1/skill-set/position/1";
-    var updatePositionRequest = new UpdatePositionRequest("test");
+    var url = "/v1/skill-set/position/{positionId}";
+    var updatePositionRequest = new UpdatePositionRequest(JsonNullable.of("test"));
     given(skillSetService.updatePositionDisplayName(any(), any())).willReturn(PositionDto.builder()
         .id(1L)
         .displayName("test")
         .build());
 
     //when
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url,1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updatePositionRequest))
     );
 
     //then
-    result.andExpect(status().isNoContent())
+    result.andExpect(status().isOk())
         .andDo(
             document("skill-set/position/update-position-displayName-success",
                 resource(
@@ -418,7 +419,7 @@ class SkillSetControllerTest extends MockMvcDocsTest {
     );
 
     //then
-    result.andExpect(status().isNoContent())
+    result.andExpect(status().isOk())
         .andDo(
             document("skill-set/position/add-position-skillList",
                 resource(
@@ -451,10 +452,10 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void delete_position_success() throws Exception {
     //given
-    var url = "/v1/skill-set/position/1";
+    var url = "/v1/skill-set/position/{positionId}";
 
     //when
-    var result = mockMvc.perform(delete(url));
+    var result = mockMvc.perform(delete(url,1L));
 
     //then
     result.andExpect(status().isOk())
@@ -733,14 +734,14 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void updateSkill_displayName_fail_duplicate() throws Exception {
     //given
-    var url = "/v1/skill-set/skill/1";
-    var updateSkillRequest = new UpdateSkillRequest("test");
+    var url = "/v1/skill-set/skill/{skillId}";
+    var updateSkillRequest = new UpdateSkillRequest(JsonNullable.of("test"));
     given(skillSetService.updateSkillDisplayName(any(), any())).willThrow(
         new BusinessException(ErrorCode.DUPLICATED_RESOURCE_EXCEPTION)
     );
 
     //when
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url, 1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updateSkillRequest))
     );
@@ -774,21 +775,21 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void updateSkill_displayName_success() throws Exception {
     //given
-    var url = "/v1/skill-set/skill/1";
-    var updateSkillRequest = new UpdateSkillRequest("test");
+    var url = "/v1/skill-set/skill/{skillId}";
+    var updateSkillRequest = new UpdateSkillRequest(JsonNullable.of("test"));
     given(skillSetService.updateSkillDisplayName(any(), any())).willReturn(SkillDto.builder()
         .id(1L)
         .displayName("test")
         .build());
 
     //when
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url, 1L)
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(updateSkillRequest))
     );
 
     //then
-    result.andExpect(status().isNoContent())
+    result.andExpect(status().isOk())
         .andDo(
             document("skill-set/skill/update-skill-displayName-success",
                 resource(
@@ -832,7 +833,7 @@ class SkillSetControllerTest extends MockMvcDocsTest {
     );
 
     //then
-    result.andExpect(status().isNoContent())
+    result.andExpect(status().isOk())
         .andDo(
             document("skill-set/skill/add-skill-to-position-list",
                 resource(
@@ -860,10 +861,10 @@ class SkillSetControllerTest extends MockMvcDocsTest {
   @Test
   public void deleteSkill_success() throws Exception {
     //given
-    var url = "/v1/skill-set/skill/1";
+    var url = "/v1/skill-set/skill/{skillId}";
 
     //when
-    var result = mockMvc.perform(delete(url));
+    var result = mockMvc.perform(delete(url, 1L));
 
     //then
     result.andExpect(status().isOk())

--- a/src/test/java/org/crops/fitserver/domain/skillset/repository/PositionRepositoryTest.java
+++ b/src/test/java/org/crops/fitserver/domain/skillset/repository/PositionRepositoryTest.java
@@ -60,11 +60,13 @@ public class PositionRepositoryTest {
     // given
     Position position1 = Position.builder()
         .displayName("test1")
+        .imageUrl("test")
         .build();
     positionRepository.save(position1);
 
     Position position2 = Position.builder()
         .displayName("test2")
+        .imageUrl("test")
         .build();
     positionRepository.save(position2);
 
@@ -80,6 +82,7 @@ public class PositionRepositoryTest {
     // given
     Position position = Position.builder()
         .displayName("test")
+        .imageUrl("test")
         .build();
     position = positionRepository.save(position);
     var positionId = position.getId();
@@ -144,6 +147,7 @@ public class PositionRepositoryTest {
     // given
     Position position = Position.builder()
         .displayName("test")
+        .imageUrl("test")
         .build();
     Skill skill = Skill.builder()
         .displayName("test")

--- a/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
@@ -16,11 +16,13 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.EnumFields;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.region.domain.Region;
+import org.crops.fitserver.domain.school.constant.SchoolType;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.domain.Skill;
 import org.crops.fitserver.domain.user.constant.LinkType;
@@ -478,7 +480,7 @@ class UserControllerTest extends MockMvcDocs {
                     .responseFields(
                         fieldWithPath("policyAgreementList[]").description("개인정보 동의 list")
                             .optional(),
-                        fieldWithPath("policyAgreementList[].policyType").type(JsonFieldType.STRING)
+                        new EnumFields(PolicyType.class).withPath("policyAgreementList[].policyType")
                             .description("개인정보 동의 타입"),
                         fieldWithPath("policyAgreementList[].version").type(JsonFieldType.STRING)
                             .description("개인정보 동의 버전"),
@@ -527,7 +529,7 @@ class UserControllerTest extends MockMvcDocs {
                     .requestFields(
                         fieldWithPath("policyAgreementList[]").description("개인정보 동의 list")
                             .optional(),
-                        fieldWithPath("policyAgreementList[].policyType").type(JsonFieldType.STRING)
+                        new EnumFields(PolicyType.class).withPath("policyAgreementList[].policyType")
                             .description("개인정보 동의 타입"),
                         fieldWithPath("policyAgreementList[].version").type(JsonFieldType.STRING)
                             .description("개인정보 동의 버전"),
@@ -588,7 +590,7 @@ class UserControllerTest extends MockMvcDocs {
                     .requestFields(
                         fieldWithPath("policyAgreementList[]").description("개인정보 동의 list")
                             .optional(),
-                        fieldWithPath("policyAgreementList[].policyType").type(JsonFieldType.STRING)
+                        new EnumFields(PolicyType.class).withPath("policyAgreementList[].policyType")
                             .description("개인정보 동의 타입"),
                         fieldWithPath("policyAgreementList[].version").type(JsonFieldType.STRING)
                             .description("개인정보 동의 버전"),
@@ -663,7 +665,7 @@ class UserControllerTest extends MockMvcDocs {
                     .requestFields(
                         fieldWithPath("policyAgreementList[]").description("개인정보 동의 list")
                             .optional(),
-                        fieldWithPath("policyAgreementList[].policyType").type(JsonFieldType.STRING)
+                        new EnumFields(PolicyType.class).withPath("policyAgreementList[].policyType")
                             .description("개인정보 동의 타입"),
                         fieldWithPath("policyAgreementList[].version").type(JsonFieldType.STRING)
                             .description("개인정보 동의 버전"),
@@ -676,7 +678,7 @@ class UserControllerTest extends MockMvcDocs {
                     .responseFields(
                         fieldWithPath("policyAgreementList[]").description("개인정보 동의 list")
                             .optional(),
-                        fieldWithPath("policyAgreementList[].policyType").type(JsonFieldType.STRING)
+                        new EnumFields(PolicyType.class).withPath("policyAgreementList[].policyType")
                             .description("개인정보 동의 타입"),
                         fieldWithPath("policyAgreementList[].version").type(JsonFieldType.STRING)
                             .description("개인정보 동의 버전"),

--- a/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
@@ -25,6 +25,7 @@ import org.crops.fitserver.domain.region.domain.Region;
 import org.crops.fitserver.domain.school.constant.SchoolType;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.domain.Skill;
+import org.crops.fitserver.domain.user.constant.BackgroundStatus;
 import org.crops.fitserver.domain.user.constant.LinkType;
 import org.crops.fitserver.domain.user.constant.PolicyType;
 import org.crops.fitserver.domain.user.constant.UserInfoStatus;
@@ -115,7 +116,7 @@ class UserControllerTest extends MockMvcDocs {
                             .description("전화번호 공개 여부").optional(),
                         fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일")
                             .optional(),
-                        fieldWithPath("backgroundStatus").type(JsonFieldType.STRING)
+                        new EnumFields(BackgroundStatus.class).withPath("backgroundStatus")
                             .description("학력/경력 상태").optional(),
                         fieldWithPath("backgroundText").type(JsonFieldType.STRING)
                             .description("학력/경력 텍스트").optional(),
@@ -211,7 +212,7 @@ class UserControllerTest extends MockMvcDocs {
                             .description("전화번호 공개 여부").optional(),
                         fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일")
                             .optional(),
-                        fieldWithPath("backgroundStatus").type(JsonFieldType.STRING)
+                        new EnumFields(BackgroundStatus.class).withPath("backgroundStatus")
                             .description("학력/경력 상태").optional(),
                         fieldWithPath("backgroundText").type(JsonFieldType.STRING)
                             .description("학력/경력 텍스트").optional(),
@@ -246,7 +247,7 @@ class UserControllerTest extends MockMvcDocs {
                             .description("전화번호 공개 여부").optional(),
                         fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일")
                             .optional(),
-                        fieldWithPath("backgroundStatus").type(JsonFieldType.STRING)
+                        new EnumFields(BackgroundStatus.class).withPath("backgroundStatus")
                             .description("학력/경력 상태").optional(),
                         fieldWithPath("backgroundText").type(JsonFieldType.STRING)
                             .description("학력/경력 텍스트").optional(),
@@ -371,7 +372,7 @@ class UserControllerTest extends MockMvcDocs {
                             .description("전화번호 공개 여부").optional(),
                         fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일")
                             .optional(),
-                        fieldWithPath("backgroundStatus").type(JsonFieldType.STRING)
+                        new EnumFields(BackgroundStatus.class).withPath("backgroundStatus")
                             .description("학력/경력 상태").optional(),
                         fieldWithPath("backgroundText").type(JsonFieldType.STRING)
                             .description("학력/경력 텍스트").optional(),
@@ -410,7 +411,7 @@ class UserControllerTest extends MockMvcDocs {
                             .description("전화번호 공개 여부").optional(),
                         fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일")
                             .optional(),
-                        fieldWithPath("backgroundStatus").type(JsonFieldType.STRING)
+                        new EnumFields(BackgroundStatus.class).withPath("backgroundStatus")
                             .description("학력/경력 상태").optional(),
                         fieldWithPath("backgroundText").type(JsonFieldType.STRING)
                             .description("학력/경력 텍스트").optional(),

--- a/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -18,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
-import org.crops.fitserver.util.MockMvcDocs;
+import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.region.domain.Region;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.domain.Skill;
@@ -34,6 +35,7 @@ import org.crops.fitserver.domain.user.dto.UserInfoDto;
 import org.crops.fitserver.domain.user.dto.request.UpdatePolicyAgreementRequest;
 import org.crops.fitserver.domain.user.dto.request.UpdateUserRequest;
 import org.crops.fitserver.domain.user.facade.UserFacade;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -46,6 +48,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 
 @WebMvcTest(UserController.class)
+@Slf4j
 class UserControllerTest extends MockMvcDocs {
 
   @MockBean
@@ -176,8 +179,7 @@ class UserControllerTest extends MockMvcDocs {
     var principalDetails = getPrincipalDetails(1L, UserRole.MEMBER);
 
     // when
-
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url)
         .contentType(MediaType.APPLICATION_JSON)
         .with(user(principalDetails))
         .with(csrf())
@@ -337,7 +339,7 @@ class UserControllerTest extends MockMvcDocs {
 
     // when
 
-    var result = mockMvc.perform(put(url)
+    var result = mockMvc.perform(patch(url)
         .contentType(MediaType.APPLICATION_JSON)
         .with(user(principalDetails))
         .with(csrf())

--- a/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import java.util.List;
-import org.crops.fitserver.domain.common.MockMvcDocsTest;
+import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.domain.region.domain.Region;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.domain.Skill;
@@ -46,7 +46,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 
 @WebMvcTest(UserController.class)
-class UserControllerTest extends MockMvcDocsTest {
+class UserControllerTest extends MockMvcDocs {
 
   @MockBean
   private UserFacade userFacade;

--- a/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
@@ -123,7 +123,7 @@ public class UserRepositoryTest {
 
     //when
 
-    ThrowingCallable result = () -> user.withNickname(updateUserRequest.getNickname());
+    ThrowingCallable result = () -> user.withNickname(updateUserRequest.getNickname().orElse(null));
     //then
     assertThatThrownBy(result).isInstanceOf(IllegalArgumentException.class);
   }

--- a/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
@@ -68,6 +68,7 @@ public class UserRepositoryTest {
         .build();
     Position position = Position.builder()
         .displayName("test")
+        .imageUrl("test")
         .build();
     Region region = Region.builder()
         .displayName("test")

--- a/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/repository/UserRepositoryTest.java
@@ -12,15 +12,18 @@ import org.crops.fitserver.domain.region.domain.Region;
 import org.crops.fitserver.domain.region.repository.RegionRepository;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.skillset.repository.PositionRepository;
+import org.crops.fitserver.domain.user.constant.BackgroundStatus;
 import org.crops.fitserver.domain.user.constant.LinkType;
-import org.crops.fitserver.domain.user.constant.UserInfoStatus;
 import org.crops.fitserver.domain.user.domain.Link;
 import org.crops.fitserver.domain.user.domain.User;
 import org.crops.fitserver.domain.user.domain.UserInfo;
 import org.crops.fitserver.domain.user.domain.UserRole;
 import org.crops.fitserver.domain.user.dto.request.UpdateUserRequest;
+import org.crops.fitserver.global.exception.BusinessException;
+import org.crops.fitserver.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -148,30 +151,38 @@ public class UserRepositoryTest {
                 .linkUrl("test2.com")
                 .build()
         ))
+        .backgroundStatus(BackgroundStatus.GRADUATE_STUDENT)
         .isOpenProfile(false)
         .positionId(this.position.getId())
         .regionId(this.region2.getId())
         .build();
 
     //when
-    user.withEmail(updateUserRequest.getEmail())
-        .withProfileImageUrl(updateUserRequest.getProfileImageUrl())
-        .withUsername(updateUserRequest.getUsername())
-        .withNickname(updateUserRequest.getNickname())
-        .withPhoneNumber(updateUserRequest.getPhoneNumber())
-        .withIsOpenPhoneNum(updateUserRequest.getIsOpenPhoneNum());
+    user = user
+        .withProfileImageUrl(
+            updateUserRequest.getProfileImageUrl().orElse(user.getProfileImageUrl()))
+        .withUsername(updateUserRequest.getUsername().orElse(user.getUsername()))
+        .withNickname(updateUserRequest.getNickname().orElse(user.getNickname()))
+        .withPhoneNumber(updateUserRequest.getPhoneNumber().orElse(user.getPhoneNumber()))
+        .withIsOpenPhoneNum(updateUserRequest.getIsOpenPhoneNum().orElse(user.isOpenPhoneNum()))
+        .withEmail(updateUserRequest.getEmail().orElse(user.getEmail()));
 
     user.getUserInfo()
         .withBackground(updateUserRequest.getBackgroundStatus(),
             updateUserRequest.getBackgroundText())
-        .withPortfolioUrl(updateUserRequest.getPortfolioUrl())
-        .withProjectCount(updateUserRequest.getProjectCount())
-        .withActivityHour(updateUserRequest.getActivityHour())
-        .withIntroduce(updateUserRequest.getIntroduce())
-        .withLinkJson(Link.parseToJson(updateUserRequest.getLinkList()))
-        .withIsOpenProfile(updateUserRequest.getIsOpenProfile())
-        .withPosition(positionRepository.findById(updateUserRequest.getPositionId()).get())
-        .withRegion(regionRepository.findById(updateUserRequest.getRegionId()).get());
+        .withPortfolioUrl(
+            updateUserRequest.getPortfolioUrl().orElse(user.getUserInfo().getPortfolioUrl()))
+        .withProjectCount(
+            updateUserRequest.getProjectCount().orElse(user.getUserInfo().getProjectCount()))
+        .withActivityHour(
+            updateUserRequest.getActivityHour().orElse(user.getUserInfo().getActivityHour()))
+        .withIntroduce(updateUserRequest.getIntroduce().orElse(user.getUserInfo().getIntroduce()))
+        .withLinkJson(updateUserRequest.getLinkList().isPresent() ? Link.parseToJson(
+            updateUserRequest.getLinkList().orElse(List.of())) : user.getUserInfo().getLinkJson())
+        .withIsOpenProfile(
+            updateUserRequest.getIsOpenProfile().orElse(user.getUserInfo().isOpenProfile()))
+        .withPosition(getNewPosition(updateUserRequest.getPositionId(), user))
+        .withRegion(getNewRegion(updateUserRequest.getRegionId(), user));
     userRepository.save(user);
     em.flush();
     em.clear();
@@ -181,5 +192,28 @@ public class UserRepositoryTest {
     assertThat(result.getUsername()).isEqualTo("test2");
     assertThat(result.getUserInfo().getRegion().getId()).isEqualTo(this.region2.getId());
   }
+
+  private Position getNewPosition(JsonNullable<Long> positionId, User user) {
+    if (!positionId.isPresent()) {
+      return user.getUserInfo().getPosition();
+    }
+    if (positionId.get() == null) {
+      return null;
+    }
+    return positionRepository.findById(positionId.get()).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
+  }
+
+  private Region getNewRegion(JsonNullable<Long> regionId, User user) {
+    if (!regionId.isPresent()) {
+      return user.getUserInfo().getRegion();
+    }
+    if (regionId.get() == null) {
+      return null;
+    }
+    return regionRepository.findById(regionId.get()).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
+  }
+
 
 }

--- a/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
+++ b/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
@@ -1,4 +1,4 @@
-package org.crops.fitserver.domain.common;
+package org.crops.fitserver.util;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
@@ -17,9 +18,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @WebMvcTest
+@Import(ObjectMapperTestConfig.class)
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public abstract class MockMvcDocsTest {
+public abstract class MockMvcDocs {
 
   protected MockMvc mockMvc;
 

--- a/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
+++ b/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
@@ -3,9 +3,13 @@ package org.crops.fitserver.util;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,13 +27,10 @@ import org.springframework.web.context.WebApplicationContext;
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class MockMvcDocs {
 
+  protected final ObjectMapper objectMapper = objectMapper();
   protected MockMvc mockMvc;
-
   @Autowired
   protected WebApplicationContext context;
-
-  @Autowired
-  protected ObjectMapper objectMapper;
 
   @BeforeEach
   protected void setUp(RestDocumentationContextProvider restDocumentation) {
@@ -41,5 +42,15 @@ public abstract class MockMvcDocs {
         )
         .alwaysDo(print())
         .build();
+  }
+
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS,
+        SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    objectMapper.registerModules(new JsonNullableModule());
+    return objectMapper;
   }
 }

--- a/src/test/java/org/crops/fitserver/util/ObjectMapperTestConfig.java
+++ b/src/test/java/org/crops/fitserver/util/ObjectMapperTestConfig.java
@@ -1,0 +1,31 @@
+package org.crops.fitserver.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class ObjectMapperTestConfig {
+
+  @Bean
+  @Primary
+  public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+    return builder -> {
+      builder.serializationInclusion(JsonInclude.Include.ALWAYS);
+      builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+      builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+      builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      builder.modules(jsonNullableModule());
+    };
+  }
+
+  @Bean
+  public JsonNullableModule jsonNullableModule() {
+    return new JsonNullableModule();
+  }
+}


### PR DESCRIPTION
## 🥔 작업한 내용
<!-- 작업 내용을 적어주세요. -->
 - patch에서 null도 초기화할 수 있게 수정
 -  기존 patch 메서드에서 JsonNullable 참고하게 수정
 - 기존 put만 있던 도메인에서 patch 추가

## ❗️ PR POINT
<!-- 덧붙이고 싶은 내용이 있다면 -->
- user쪽은 복잡하니, skill-set쪽 코드를 보고 코멘트 달아주시면 될 거 같습니다. 두 도메인의 수정사항은 거의 일치합니다.

## 🔒 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요.-->
- resolved: #31 
