### PR TITLE
[feat] matching 관련 로직 추가

### DIFF
--- a/src/main/java/org/crops/fitserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/crops/fitserver/domain/auth/controller/AuthController.java
@@ -45,4 +45,16 @@ public class AuthController {
         authFacade.getSocialLoginPageUrl(socialPlatform);
     return ResponseEntity.ok(socialLoginPageResponse);
   }
+
+  @PostMapping("/social/test/login")
+  public ResponseEntity<TokenResponse> testLogin() {
+    TokenResponse tokenResponse = authFacade.testLogin();
+    return ResponseEntity.ok(tokenResponse);
+  }
+
+  @PostMapping("/social/test/login/{userId}")
+  public ResponseEntity<TokenResponse> testLogin(@PathVariable(name = "userId") Long userId) {
+    TokenResponse tokenResponse = authFacade.testLogin(userId);
+    return ResponseEntity.ok(tokenResponse);
+  }
 }

--- a/src/main/java/org/crops/fitserver/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/org/crops/fitserver/domain/auth/facade/AuthFacade.java
@@ -11,4 +11,8 @@ public interface AuthFacade {
       SocialPlatform socialPlatform);
 
   SocialLoginPageResponse getSocialLoginPageUrl(SocialPlatform socialPlatform);
+
+  TokenResponse testLogin();
+
+  TokenResponse testLogin(Long userId);
 }

--- a/src/main/java/org/crops/fitserver/domain/auth/facade/impl/AuthFacadeImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/auth/facade/impl/AuthFacadeImpl.java
@@ -5,6 +5,8 @@ import org.crops.fitserver.domain.auth.dto.response.SocialLoginPageResponse;
 import org.crops.fitserver.domain.auth.service.OAuthService;
 import org.crops.fitserver.domain.auth.service.provider.OAuthServiceProvider;
 import org.crops.fitserver.domain.auth.facade.AuthFacade;
+import org.crops.fitserver.domain.user.domain.UserRole;
+import org.crops.fitserver.domain.user.repository.UserRepository;
 import org.crops.fitserver.global.jwt.JwtProvider;
 import org.crops.fitserver.global.jwt.TokenInfo;
 import org.crops.fitserver.domain.user.domain.SocialPlatform;
@@ -19,6 +21,7 @@ public class AuthFacadeImpl implements AuthFacade {
 
   private final OAuthServiceProvider oAuthServiceProvider;
   private final JwtProvider jwtProvider;
+  private final UserRepository userRepository;
 
   @Override
   @Transactional
@@ -37,5 +40,22 @@ public class AuthFacadeImpl implements AuthFacade {
   public SocialLoginPageResponse getSocialLoginPageUrl(SocialPlatform socialPlatform) {
     OAuthService oAuthService = oAuthServiceProvider.getService(socialPlatform);
     return SocialLoginPageResponse.from(oAuthService.getLoginPageUrl());
+  }
+
+  @Override
+  public TokenResponse testLogin() {
+    User user = User.builder().userRole(UserRole.NON_MEMBER).build();
+    user = userRepository.save(user);
+    return TokenResponse.from(
+        jwtProvider.createTokenCollection(
+            TokenInfo.from(user)));
+  }
+
+  @Override
+  public TokenResponse testLogin(Long userId) {
+    User user = userRepository.findById(userId).orElseThrow();
+    return TokenResponse.from(
+        jwtProvider.createTokenCollection(
+            TokenInfo.from(user)));
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingProcessor.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingProcessor.java
@@ -1,0 +1,116 @@
+package org.crops.fitserver.domain.matching.batch;
+
+
+import static java.util.stream.Collectors.groupingBy;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.crops.fitserver.domain.chat.service.ChatRoomService;
+import org.crops.fitserver.domain.matching.entity.Matching;
+import org.crops.fitserver.domain.matching.entity.MatchingRoom;
+import org.crops.fitserver.domain.matching.repository.MatchingRepository;
+import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
+import org.crops.fitserver.domain.skillset.constant.PositionType;
+import org.springframework.transaction.annotation.Transactional;
+
+public class MatchingProcessor {
+
+  private final MatchingRepository matchingRepository;
+  private final MatchingRoomRepository matchingRoomRepository;
+  private final ChatRoomService chatRoomService;
+  private List<Matching> matchingList;
+  private List<MatchingRoom> matchingRoomList;
+
+  private Map<PositionType, List<Matching>> matchingMap;
+
+  public MatchingProcessor(MatchingRepository matchingRepository,
+      MatchingRoomRepository matchingRoomRepository, ChatRoomService chatRoomService) {
+    this.matchingRepository = matchingRepository;
+    this.matchingRoomRepository = matchingRoomRepository;
+    this.chatRoomService = chatRoomService;
+
+    init();
+  }
+
+  private void init() {
+    matchingList = matchingRepository.findMatchingWithoutRoom();
+    matchingRoomList = matchingRoomRepository.findMatchingRoomNotComplete();
+
+    matchingMap = matchingList.stream()
+        .collect(groupingBy(matching -> matching.getPosition().getType()));
+
+    //매칭 만료 시간 순으로 정렬
+    matchingMap.forEach((key, value) -> {
+      value.sort(Comparator.comparing(Matching::getExpiredAt));
+    });
+  }
+
+  //최소 인원이 채워지지 않은 룸에 매칭을 시도
+  @Transactional
+  public void insertToNotEnoughRoom() {
+    var notEnoughRoomList = matchingRoomList.stream()
+        .filter(MatchingRoom::isNotEnough).toList();
+    notEnoughRoomList
+        .forEach(matchingRoom -> matchingMap.forEach((key, value) -> {
+          if (matchingRoom.isNotEnough(key)) {
+            matchingRoom.addMatching(value.remove(0));
+          }
+        }));
+
+    matchingRoomRepository.saveAll(notEnoughRoomList);
+  }
+
+  //룸이 없는 매칭끼리 최소인원 이상이 되도록 룸을 생성
+  @Transactional
+  public void createNewRoom() {
+    var size = matchingMap.values().stream().mapToInt(List::size).min().orElse(0);
+
+    for (int i = 0; i < size; i++) {
+      var matchingList = new ArrayList<Matching>();
+      matchingMap.forEach((key, value) -> {
+        matchingList.add(value.remove(0));
+      });
+      var newRoom = MatchingRoom.createRoom(matchingList, chatRoomService.createChatRoom().getId());
+      matchingRoomRepository.save(newRoom);
+    }
+  }
+
+  //최소인원수를 만족한 룸을 찾아서 매칭을 시도
+  public void joinRoom() {
+
+    //frontend, backend, designer, planner순으로 룸에 들어가기
+    joinRoomByType(PositionType.FRONTEND);
+    joinRoomByType(PositionType.BACKEND);
+    joinRoomByType(PositionType.DESIGNER);
+    joinRoomByType(PositionType.PLANNER);
+  }
+
+  private void joinRoomByType(PositionType positionType) {
+    var matchingList = matchingMap.get(positionType);
+    var roomList = new ArrayList<>(matchingRoomList.stream()
+        .filter(matchingRoom -> matchingRoom.isCanInsertPosition(positionType))
+        .toList());
+
+    matchingList.forEach(matching -> {
+      var room = roomList.stream()
+          .filter(matchingRoom ->
+              matchingRoom.isCanInsertPosition(positionType) &&
+                  matchingRoom.getRequiredSkillIds(positionType).retainAll(
+                      matching.getUser().getUserInfo()
+                          .getUserInfoSkills().stream()
+                          .map(userInfoSkill -> userInfoSkill.getSkill().getId()).toList()
+                  )
+          )
+          .findFirst()
+          .orElse(null);
+
+      if (room != null) {
+        room.addMatching(matching);
+        matchingRoomRepository.save(room);
+        roomList.remove(room);
+      }
+    });
+  }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
@@ -1,10 +1,8 @@
 package org.crops.fitserver.domain.matching.batch;
 
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.chat.service.ChatRoomService;
-import org.crops.fitserver.domain.matching.constant.Constant;
 import org.crops.fitserver.domain.matching.repository.MatchingRepository;
 import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
 import org.crops.fitserver.domain.matching.service.MatchingService;
@@ -27,7 +25,8 @@ public class MatchingScheduler {
   @Scheduled(cron = "1/10 * * * * *")
   @Transactional
   public void matching() {
-    var matchingProcessor = new MatchingProcessor(matchingRepository, matchingRoomRepository, chatRoomService);
+    var matchingProcessor = new MatchingProcessor(matchingRepository, matchingRoomRepository,
+        chatRoomService);
 
     matchingProcessor.insertToNotEnoughRoom();
     matchingProcessor.createNewRoom();

--- a/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
@@ -1,10 +1,16 @@
 package org.crops.fitserver.domain.matching.batch;
 
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.chat.service.ChatRoomService;
+import org.crops.fitserver.domain.matching.constant.Constant;
+import org.crops.fitserver.domain.matching.repository.MatchingRepository;
+import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
 import org.crops.fitserver.domain.matching.service.MatchingService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
@@ -12,15 +18,25 @@ import org.springframework.stereotype.Component;
 public class MatchingScheduler {
 
   private final MatchingService matchingService;
+  private final MatchingRepository matchingRepository;
+  private final MatchingRoomRepository matchingRoomRepository;
+  private final ChatRoomService chatRoomService;
 
 
   //매 10초마다
-  @Scheduled(cron = "0/10 * * * * *")
+  @Scheduled(cron = "1/10 * * * * *")
+  @Transactional
   public void matching() {
+    var matchingProcessor = new MatchingProcessor(matchingRepository, matchingRoomRepository, chatRoomService);
+
+    matchingProcessor.insertToNotEnoughRoom();
+    matchingProcessor.createNewRoom();
+    matchingProcessor.joinRoom();
 
   }
 
   @Scheduled(cron = "0/10 * * * * *")
+  @Transactional
   public void expireMatching() {
     var expriredMatchingList = matchingService.expireMatchingAll();
 

--- a/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
@@ -25,12 +25,17 @@ public class MatchingScheduler {
   @Scheduled(cron = "1/10 * * * * *")
   @Transactional
   public void matching() {
+    log.info("매칭 시작");
     var matchingProcessor = new MatchingProcessor(matchingRepository, matchingRoomRepository,
         chatRoomService);
 
-    matchingProcessor.insertToNotEnoughRoom();
-    matchingProcessor.createNewRoom();
-    matchingProcessor.joinRoom();
+    long matchingCount = 0;
+
+    matchingCount += matchingProcessor.insertToNotEnoughRoom();
+    matchingCount += matchingProcessor.createNewRoom();
+    matchingCount += matchingProcessor.joinRoom();
+
+    log.info("매칭 종료 : {}개 매칭", matchingCount);
 
   }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/batch/MatchingScheduler.java
@@ -1,0 +1,33 @@
+package org.crops.fitserver.domain.matching.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.matching.service.MatchingService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MatchingScheduler {
+
+  private final MatchingService matchingService;
+
+
+  //매 10초마다
+  @Scheduled(cron = "0/10 * * * * *")
+  public void matching() {
+
+  }
+
+  @Scheduled(cron = "0/10 * * * * *")
+  public void expireMatching() {
+    var expriredMatchingList = matchingService.expireMatchingAll();
+
+    expriredMatchingList.forEach(matching -> {
+      log.info("매칭 만료 : {}", matching.getId());
+      //TODO: 만료된 매칭에 대한 알림 처리 로직 추가
+    });
+  }
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
@@ -1,6 +1,5 @@
 package org.crops.fitserver.domain.matching.constant;
 
-import java.util.List;
 import java.util.Map;
 import org.crops.fitserver.domain.skillset.constant.PositionType;
 

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
@@ -1,0 +1,6 @@
+package org.crops.fitserver.domain.matching.constant;
+
+public class Constant {
+
+  public static final int MATCHING_EXPIRE_DAYS = 3;
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java
@@ -1,6 +1,34 @@
 package org.crops.fitserver.domain.matching.constant;
 
+import java.util.List;
+import java.util.Map;
+import org.crops.fitserver.domain.skillset.constant.PositionType;
+
 public class Constant {
 
   public static final int MATCHING_EXPIRE_DAYS = 3;
+
+  public static final Map<PositionType, Integer> MINIMUM_REQUIRED_POSITIONS = Map.of(
+      PositionType.PLANNER, 1,
+      PositionType.DESIGNER, 1,
+      PositionType.BACKEND, 1,
+      PositionType.FRONTEND, 1
+  );
+
+  public static final Map<PositionType, Integer> MAXIMUM_POSITIONS = Map.of(
+      PositionType.PLANNER, 2,
+      PositionType.DESIGNER, 2,
+      PositionType.BACKEND, 3,
+      PositionType.FRONTEND, 4
+  );
+
+
+  public static final Map<PositionType, Integer> MULTIPLE_POSITION_COMPARE_TO_OTHER_POSITIONS = Map.of(
+      PositionType.PLANNER, 1,
+      PositionType.DESIGNER, 1,
+      PositionType.BACKEND, 2,
+      PositionType.FRONTEND, 2
+  );
+
+
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingConstants.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingConstants.java
@@ -3,7 +3,7 @@ package org.crops.fitserver.domain.matching.constant;
 import java.util.Map;
 import org.crops.fitserver.domain.skillset.constant.PositionType;
 
-public class Constant {
+public class MatchingConstants {
 
   public static final int MATCHING_EXPIRE_DAYS = 3;
 

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
@@ -6,5 +6,7 @@ public enum MatchingStatus {
   ACCEPTED,
   EXPIRED,
   CANCELED,
+  FORCED_OUT,
+  EXITED,
   COMPLETED
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
@@ -3,6 +3,8 @@ package org.crops.fitserver.domain.matching.constant;
 public enum MatchingStatus {
   WAITING,
   MATCHED,
+  ACCEPTED,
   EXPIRED,
-  CANCELED
+  CANCELED,
+  COMPLETED
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/constant/MatchingStatus.java
@@ -1,0 +1,8 @@
+package org.crops.fitserver.domain.matching.constant;
+
+public enum MatchingStatus {
+  WAITING,
+  MATCHED,
+  EXPIRED,
+  CANCELED
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -1,0 +1,58 @@
+package org.crops.fitserver.domain.matching.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
+import org.crops.fitserver.domain.matching.service.MatchingService;
+import org.crops.fitserver.global.annotation.CurrentUserId;
+import org.crops.fitserver.global.annotation.V1;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@V1
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/matching")
+public class MatchingController {
+
+  private final MatchingService matchingService;
+
+  @PostMapping("/")
+  public ResponseEntity<CreateMatchingResponse> createMatching(
+      @CurrentUserId Long userId
+  ) {
+    return ResponseEntity.ok(matchingService.createMatching(userId));
+  }
+
+  @GetMapping("/")
+  public ResponseEntity<GetMatchingResponse> getMatching(
+      @CurrentUserId Long userId
+  ) {
+    return ResponseEntity.ok(matchingService.getMatching(userId));
+  }
+
+  @GetMapping("/room/{roomId}")
+  public ResponseEntity<GetMatchingRoomResponse> getMatchingRoom(
+      @CurrentUserId Long userId,
+      @PathVariable("roomId") Long roomId
+  ) {
+    return ResponseEntity.ok(matchingService.getMatchingRoom(userId, roomId));
+  }
+
+  @PostMapping("/cancel")
+  public ResponseEntity<Void> cancelMatching(
+      @CurrentUserId Long userId
+  ) {
+    matchingService.cancelMatching(userId);
+    return ResponseEntity.ok().build();
+  }
+
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -49,13 +49,22 @@ public class MatchingController {
   }
 
   //강제퇴장
-  @PostMapping("/rom/{roomId}/force-out")
+  @PostMapping("/room/{roomId}/force-out")
   public ResponseEntity<Void> forceOut(
       @CurrentUserId Long userId,
       @PathVariable("roomId") Long roomId,
       @RequestBody ForceOutRequest forceOutRequest
   ) {
     matchingService.forceOut(userId, roomId, forceOutRequest.userId());
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/room/{roomId}/complete")
+  public ResponseEntity<Void> completeMatching(
+      @CurrentUserId Long userId,
+      @PathVariable("roomId") Long roomId
+  ) {
+    matchingService.completeMatching(userId, roomId);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -26,14 +26,14 @@ public class MatchingController {
 
   private final MatchingService matchingService;
 
-  @PostMapping("/")
+  @PostMapping
   public ResponseEntity<CreateMatchingResponse> createMatching(
       @CurrentUserId Long userId
   ) {
     return ResponseEntity.ok(matchingService.createMatching(userId));
   }
 
-  @GetMapping("/")
+  @GetMapping
   public ResponseEntity<GetMatchingResponse> getMatching(
       @CurrentUserId Long userId
   ) {
@@ -48,7 +48,6 @@ public class MatchingController {
     return ResponseEntity.ok(matchingService.getMatchingRoom(userId, roomId));
   }
 
-  //강제퇴장
   @PostMapping("/room/{roomId}/force-out")
   public ResponseEntity<Void> forceOut(
       @CurrentUserId Long userId,
@@ -56,6 +55,15 @@ public class MatchingController {
       @RequestBody ForceOutRequest forceOutRequest
   ) {
     matchingService.forceOut(userId, roomId, forceOutRequest.userId());
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/room/{roomId}/ready")
+  public ResponseEntity<Void> readyMatching(
+      @CurrentUserId Long userId,
+      @PathVariable("roomId") Long roomId
+  ) {
+    matchingService.readyMatching(userId, roomId);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -2,6 +2,7 @@ package org.crops.fitserver.domain.matching.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.matching.dto.request.ForceOutRequest;
 import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,6 +46,17 @@ public class MatchingController {
       @PathVariable("roomId") Long roomId
   ) {
     return ResponseEntity.ok(matchingService.getMatchingRoom(userId, roomId));
+  }
+
+  //강제퇴장
+  @PostMapping("/rom/{roomId}/force-out")
+  public ResponseEntity<Void> forceOut(
+      @CurrentUserId Long userId,
+      @PathVariable("roomId") Long roomId,
+      @RequestBody ForceOutRequest forceOutRequest
+  ) {
+    matchingService.forceOut(userId, roomId, forceOutRequest.userId());
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/cancel")

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -40,6 +40,15 @@ public class MatchingController {
     return ResponseEntity.ok(matchingService.getMatching(userId));
   }
 
+
+  @PostMapping("/cancel")
+  public ResponseEntity<Void> cancelMatching(
+      @CurrentUserId Long userId
+  ) {
+    matchingService.cancel(userId);
+    return ResponseEntity.ok().build();
+  }
+
   @GetMapping("/room/{roomId}")
   public ResponseEntity<GetMatchingRoomResponse> getMatchingRoom(
       @CurrentUserId Long userId,
@@ -63,7 +72,7 @@ public class MatchingController {
       @CurrentUserId Long userId,
       @PathVariable("roomId") Long roomId
   ) {
-    matchingService.readyMatching(userId, roomId);
+    matchingService.ready(userId, roomId);
     return ResponseEntity.ok().build();
   }
 
@@ -72,15 +81,15 @@ public class MatchingController {
       @CurrentUserId Long userId,
       @PathVariable("roomId") Long roomId
   ) {
-    matchingService.completeMatching(userId, roomId);
+    matchingService.complete(userId, roomId);
     return ResponseEntity.ok().build();
   }
-
-  @PostMapping("/cancel")
+  @PostMapping("/room/{roomId}/cancel")
   public ResponseEntity<Void> cancelMatching(
-      @CurrentUserId Long userId
+      @CurrentUserId Long userId,
+      @PathVariable("roomId") Long roomId
   ) {
-    matchingService.cancelMatching(userId);
+    matchingService.exit(userId, roomId);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/controller/MatchingController.java
@@ -2,9 +2,8 @@ package org.crops.fitserver.domain.matching.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
 import org.crops.fitserver.domain.matching.dto.request.ForceOutRequest;
-import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
-import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.service.MatchingService;
 import org.crops.fitserver.global.annotation.CurrentUserId;
@@ -27,14 +26,14 @@ public class MatchingController {
   private final MatchingService matchingService;
 
   @PostMapping
-  public ResponseEntity<CreateMatchingResponse> createMatching(
+  public ResponseEntity<MatchingDto> createMatching(
       @CurrentUserId Long userId
   ) {
     return ResponseEntity.ok(matchingService.createMatching(userId));
   }
 
   @GetMapping
-  public ResponseEntity<GetMatchingResponse> getMatching(
+  public ResponseEntity<MatchingDto> getMatching(
       @CurrentUserId Long userId
   ) {
     return ResponseEntity.ok(matchingService.getMatching(userId));
@@ -84,6 +83,7 @@ public class MatchingController {
     matchingService.complete(userId, roomId);
     return ResponseEntity.ok().build();
   }
+
   @PostMapping("/room/{roomId}/cancel")
   public ResponseEntity<Void> cancelMatching(
       @CurrentUserId Long userId,

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
@@ -4,16 +4,17 @@ import java.time.LocalDateTime;
 import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 import org.crops.fitserver.domain.matching.entity.Matching;
 
-public record MatchingDto(Long matchingId,
-                          Long roomId,
-                          Long positionId,
-                          LocalDateTime createdAt,
-                          LocalDateTime expiredAt,
-                          MatchingStatus status) {
+public record MatchingDto(
+    Long userId,
+    Long roomId,
+    Long positionId,
+    LocalDateTime createdAt,
+    LocalDateTime expiredAt,
+    MatchingStatus status) {
 
   public static MatchingDto from(Matching matching) {
     return new MatchingDto(
-        matching.getId(),
+        matching.getUser().getId(),
         matching.getMatchingRoom() != null ? matching.getMatchingRoom().getId() : null,
         matching.getPosition().getId(),
         matching.getCreatedAt(),

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
@@ -1,0 +1,24 @@
+package org.crops.fitserver.domain.matching.dto;
+
+import java.time.LocalDateTime;
+import org.crops.fitserver.domain.matching.constant.MatchingStatus;
+import org.crops.fitserver.domain.matching.entity.Matching;
+
+public record MatchingDto(Long matchingId,
+                          Long roomId,
+                          Long PositionId,
+                          LocalDateTime createdAt,
+                          LocalDateTime expiredAt,
+                          MatchingStatus status) {
+  public static MatchingDto from(Matching matching) {
+    return new MatchingDto(
+        matching.getId(),
+        matching.getMatchingRoom().getId(),
+        matching.getPosition().getId(),
+        matching.getCreatedAt(),
+        matching.getExpiredAt(),
+        matching.getStatus()
+    );
+  }
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingDto.java
@@ -6,14 +6,15 @@ import org.crops.fitserver.domain.matching.entity.Matching;
 
 public record MatchingDto(Long matchingId,
                           Long roomId,
-                          Long PositionId,
+                          Long positionId,
                           LocalDateTime createdAt,
                           LocalDateTime expiredAt,
                           MatchingStatus status) {
+
   public static MatchingDto from(Matching matching) {
     return new MatchingDto(
         matching.getId(),
-        matching.getMatchingRoom().getId(),
+        matching.getMatchingRoom() != null ? matching.getMatchingRoom().getId() : null,
         matching.getPosition().getId(),
         matching.getCreatedAt(),
         matching.getExpiredAt(),

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingMemberView.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingMemberView.java
@@ -1,0 +1,24 @@
+package org.crops.fitserver.domain.matching.dto;
+
+import org.crops.fitserver.domain.matching.entity.Matching;
+
+public record MatchingMemberView(
+    Long userId,
+    Long positionId,
+    String username,
+    String profileImageUrl,
+    Boolean isReady,
+    Boolean isHost
+) {
+
+  public static MatchingMemberView from(Matching matching) {
+    return new MatchingMemberView(
+        matching.getUser().getId(),
+        matching.getPosition().getId(),
+        matching.getUser().getUsername(),
+        matching.getUser().getProfileImageUrl(),
+        matching.isReady(),
+        matching.isHost()
+    );
+  }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingUserView.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/MatchingUserView.java
@@ -2,7 +2,7 @@ package org.crops.fitserver.domain.matching.dto;
 
 import org.crops.fitserver.domain.matching.entity.Matching;
 
-public record MatchingMemberView(
+public record MatchingUserView(
     Long userId,
     Long positionId,
     String username,
@@ -11,8 +11,8 @@ public record MatchingMemberView(
     Boolean isHost
 ) {
 
-  public static MatchingMemberView from(Matching matching) {
-    return new MatchingMemberView(
+  public static MatchingUserView from(Matching matching) {
+    return new MatchingUserView(
         matching.getUser().getId(),
         matching.getPosition().getId(),
         matching.getUser().getUsername(),

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/request/ForceOutRequest.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/request/ForceOutRequest.java
@@ -1,0 +1,9 @@
+package org.crops.fitserver.domain.matching.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ForceOutRequest(
+    @NotNull Long userId
+) {
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/CreateMatchingResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/CreateMatchingResponse.java
@@ -1,0 +1,13 @@
+package org.crops.fitserver.domain.matching.dto.response;
+
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
+import org.crops.fitserver.domain.matching.entity.Matching;
+
+public record CreateMatchingResponse(
+    MatchingDto matching
+) {
+
+  public static CreateMatchingResponse from(Matching matching) {
+    return new CreateMatchingResponse(MatchingDto.from(matching));
+  }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingResponse.java
@@ -3,10 +3,11 @@ package org.crops.fitserver.domain.matching.dto.response;
 import org.crops.fitserver.domain.matching.dto.MatchingDto;
 import org.crops.fitserver.domain.matching.entity.Matching;
 
-public record GetMatchingResponse (
+public record GetMatchingResponse(
     MatchingDto matching
-){
-    public static GetMatchingResponse from(Matching matching) {
-        return new GetMatchingResponse(MatchingDto.from(matching));
-    }
+) {
+
+  public static GetMatchingResponse from(Matching matching) {
+    return new GetMatchingResponse(MatchingDto.from(matching));
+  }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingResponse.java
@@ -1,0 +1,12 @@
+package org.crops.fitserver.domain.matching.dto.response;
+
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
+import org.crops.fitserver.domain.matching.entity.Matching;
+
+public record GetMatchingResponse (
+    MatchingDto matching
+){
+    public static GetMatchingResponse from(Matching matching) {
+        return new GetMatchingResponse(MatchingDto.from(matching));
+    }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
 public record GetMatchingRoomResponse(
-    Long id,
+    Long matchingRoomId,
     Long chatRoomId,
     Boolean isComplete,
     LocalDateTime completedAt,

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -1,6 +1,8 @@
 package org.crops.fitserver.domain.matching.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import org.crops.fitserver.domain.matching.dto.MatchingMemberView;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
 public record GetMatchingRoomResponse(
@@ -8,16 +10,21 @@ public record GetMatchingRoomResponse(
     Long chatRoomId,
     Boolean isCompleted,
     LocalDateTime completedAt,
-    Long hostUserId
+    Long hostUserId,
+    List<MatchingMemberView> matchingUserList
 ) {
 
   public static GetMatchingRoomResponse from(MatchingRoom matchingRoom) {
     return new GetMatchingRoomResponse(
+
         matchingRoom.getId(),
         matchingRoom.getChatRoomId(),
         matchingRoom.getIsCompleted(),
         matchingRoom.getCompletedAt(),
-        matchingRoom.getHostUserId()
+        matchingRoom.getHostUserId(),
+        matchingRoom.getMatchingList().stream()
+            .map(MatchingMemberView::from)
+            .toList()
     );
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -1,12 +1,13 @@
 package org.crops.fitserver.domain.matching.dto.response;
 
+import java.time.LocalDateTime;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
 public record GetMatchingRoomResponse(
     Long id,
     Long chatRoomId,
-    Boolean isMatched,
-    Long matchedAt,
+    Boolean isComplete,
+    LocalDateTime completedAt,
     Long hostUserId
 ) {
 
@@ -14,8 +15,8 @@ public record GetMatchingRoomResponse(
     return new GetMatchingRoomResponse(
         matchingRoom.getId(),
         matchingRoom.getChatRoomId(),
-        matchingRoom.getIsMatched(),
-        matchingRoom.getMatchedAt(),
+        matchingRoom.getIsComplete(),
+        matchingRoom.getCompletedAt(),
         matchingRoom.getHostUserId()
     );
   }

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -6,7 +6,7 @@ import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 public record GetMatchingRoomResponse(
     Long matchingRoomId,
     Long chatRoomId,
-    Boolean isComplete,
+    Boolean isCompleted,
     LocalDateTime completedAt,
     Long hostUserId
 ) {
@@ -15,7 +15,7 @@ public record GetMatchingRoomResponse(
     return new GetMatchingRoomResponse(
         matchingRoom.getId(),
         matchingRoom.getChatRoomId(),
-        matchingRoom.getIsComplete(),
+        matchingRoom.getIsCompleted(),
         matchingRoom.getCompletedAt(),
         matchingRoom.getHostUserId()
     );

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -2,29 +2,29 @@ package org.crops.fitserver.domain.matching.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import org.crops.fitserver.domain.matching.dto.MatchingMemberView;
+import lombok.Builder;
+import org.crops.fitserver.domain.matching.dto.MatchingUserView;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
+@Builder
 public record GetMatchingRoomResponse(
     Long matchingRoomId,
     Long chatRoomId,
     Boolean isCompleted,
     LocalDateTime completedAt,
     Long hostUserId,
-    List<MatchingMemberView> matchingUserList
+    List<MatchingUserView> matchingUserList
 ) {
-
   public static GetMatchingRoomResponse from(MatchingRoom matchingRoom) {
-    return new GetMatchingRoomResponse(
-
-        matchingRoom.getId(),
-        matchingRoom.getChatRoomId(),
-        matchingRoom.getIsCompleted(),
-        matchingRoom.getCompletedAt(),
-        matchingRoom.getHostUserId(),
-        matchingRoom.getMatchingList().stream()
-            .map(MatchingMemberView::from)
-            .toList()
-    );
+    return GetMatchingRoomResponse.builder()
+        .matchingRoomId(matchingRoom.getId())
+        .chatRoomId(matchingRoom.getChatRoomId())
+        .isCompleted(matchingRoom.getIsCompleted())
+        .completedAt(matchingRoom.getCompletedAt())
+        .hostUserId(matchingRoom.getHostUserId())
+        .matchingUserList(matchingRoom.getMatchingList().stream()
+            .map(MatchingUserView::from)
+            .toList())
+        .build();
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/dto/response/GetMatchingRoomResponse.java
@@ -1,0 +1,22 @@
+package org.crops.fitserver.domain.matching.dto.response;
+
+import org.crops.fitserver.domain.matching.entity.MatchingRoom;
+
+public record GetMatchingRoomResponse(
+    Long id,
+    Long chatRoomId,
+    Boolean isMatched,
+    Long matchedAt,
+    Long hostUserId
+) {
+
+  public static GetMatchingRoomResponse from(MatchingRoom matchingRoom) {
+    return new GetMatchingRoomResponse(
+        matchingRoom.getId(),
+        matchingRoom.getChatRoomId(),
+        matchingRoom.getIsMatched(),
+        matchingRoom.getMatchedAt(),
+        matchingRoom.getHostUserId()
+    );
+  }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
@@ -63,7 +63,7 @@ public class Matching extends BaseTimeEntity {
 
   @Column(name = "status", nullable = false)
   @Enumerated(value = EnumType.STRING)
-  private MatchingStatus status = MatchingStatus.WAITING;
+  private MatchingStatus status;
 
   public static Matching create(User user, Position position) {
     return Matching.builder()

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
@@ -2,6 +2,8 @@ package org.crops.fitserver.domain.matching.entity;
 
 import static org.crops.fitserver.domain.matching.constant.Constant.MATCHING_EXPIRE_DAYS;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -52,9 +54,11 @@ public class Matching extends BaseTimeEntity {
   private Position position;
 
   @Column(name = "expired_at", nullable = true)
+  @JsonDeserialize(using = LocalDateDeserializer.class)
   private LocalDateTime expiredAt;
 
   @Column(name = "last_batch_at", nullable = true)
+  @JsonDeserialize(using = LocalDateDeserializer.class)
   private LocalDateTime lastBatchAt;
 
   @Column(name = "status", nullable = false)

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
@@ -1,6 +1,6 @@
 package org.crops.fitserver.domain.matching.entity;
 
-import static org.crops.fitserver.domain.matching.constant.Constant.MATCHING_EXPIRE_DAYS;
+import static org.crops.fitserver.domain.matching.constant.MatchingConstants.MATCHING_EXPIRE_DAYS;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
@@ -1,0 +1,68 @@
+package org.crops.fitserver.domain.matching.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Cleanup;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.crops.fitserver.domain.matching.constant.MatchingStatus;
+import org.crops.fitserver.domain.skillset.domain.Position;
+import org.crops.fitserver.domain.user.domain.User;
+import org.crops.fitserver.global.entity.BaseTimeEntity;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Where(clause = "is_deleted = false")
+public class Matching extends BaseTimeEntity {
+
+  @Id
+  @Column(name = "matching_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "matching_room_id", nullable = true)
+  private MatchingRoom matchingRoom;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "position_id", nullable = false)
+  private Position position;
+
+  @Column(name = "expired_at", nullable = true)
+  private LocalDateTime expiredAt;
+
+  @Column(name = "last_batch_at", nullable = true)
+  private LocalDateTime lastBatchAt;
+
+  @Column(name = "status", nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private MatchingStatus status = MatchingStatus.WAITING;
+
+
+  public void cancel() {
+    this.status = MatchingStatus.CANCELED;
+    this.matchingRoom = null;
+  }
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/Matching.java
@@ -24,6 +24,8 @@ import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 import org.crops.fitserver.domain.skillset.domain.Position;
 import org.crops.fitserver.domain.user.domain.User;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
+import org.crops.fitserver.global.exception.BusinessException;
+import org.crops.fitserver.global.exception.ErrorCode;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.Where;
 
@@ -107,4 +109,21 @@ public class Matching extends BaseTimeEntity {
     return matchingRoom != null && matchingRoom.getHostUserId().equals(user.getId());
   }
 
+  public void complete() {
+    this.status = MatchingStatus.COMPLETED;
+  }
+
+  public void ready() {
+    if (this.status != MatchingStatus.MATCHED) {
+      throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION);
+    }
+    if (isHost()) {
+      throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION);
+    }
+    this.status = MatchingStatus.ACCEPTED;
+  }
+
+  public boolean isReady() {
+    return this.status == MatchingStatus.ACCEPTED;
+  }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -160,5 +161,17 @@ public class MatchingRoom extends BaseTimeEntity {
     isCompleted = true;
     completedAt = LocalDateTime.now();
     matchingList.forEach(Matching::complete);
+  }
+
+
+  //백엔드와 프론트엔드는 포지션 id까지 일치해야 한다.
+  public Optional<Long> getRequiredPositionId(PositionType positionType) {
+    if(PositionType.PLANNER.equals(positionType) || PositionType.DESIGNER.equals(positionType)) {
+      return Optional.empty();
+    }
+    return matchingList.stream()
+        .filter(m -> m.getPosition().getType().equals(positionType))
+        .map(m -> m.getPosition().getId())
+        .findFirst();
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -1,11 +1,17 @@
 package org.crops.fitserver.domain.matching.entity;
 
+import static java.util.stream.Collectors.groupingBy;
+import static org.crops.fitserver.domain.matching.constant.Constant.MAXIMUM_POSITIONS;
+import static org.crops.fitserver.domain.matching.constant.Constant.MINIMUM_REQUIRED_POSITIONS;
+import static org.crops.fitserver.domain.matching.constant.Constant.MULTIPLE_POSITION_COMPARE_TO_OTHER_POSITIONS;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -13,6 +19,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.crops.fitserver.domain.skillset.constant.PositionType;
+import org.crops.fitserver.domain.skillset.domain.Skill;
+import org.crops.fitserver.domain.user.domain.UserInfoSkill;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
 import org.crops.fitserver.global.exception.BusinessException;
 import org.crops.fitserver.global.exception.ErrorCode;
@@ -36,11 +45,11 @@ public class MatchingRoom extends BaseTimeEntity {
   @Column(name = "chat_room_id", nullable = false)
   private Long chatRoomId;
 
-  @Column(name = "is_matched", nullable = false)
-  private Boolean isMatched;
+  @Column(name = "is_complete", nullable = false)
+  private Boolean isComplete;
 
-  @Column(name = "matched_at", nullable = true)
-  private Long matchedAt;
+  @Column(name = "completed_at", nullable = true)
+  private LocalDateTime completedAt;
 
   @Column(name = "host_user_id", nullable = false)
   private Long hostUserId;
@@ -55,8 +64,8 @@ public class MatchingRoom extends BaseTimeEntity {
     return MatchingRoom.builder()
         .matchingList(matchingList)
         .chatRoomId(chatRoomId)
-        .isMatched(false)
-        .matchedAt(null)
+        .isComplete(false)
+        .completedAt(null)
         .hostUserId(matchingList.get(0).getUser().getId())
         .build();
   }
@@ -85,5 +94,61 @@ public class MatchingRoom extends BaseTimeEntity {
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
 
     hostUserId = newHost.getUser().getId();
+  }
+
+  public boolean isNotEnough() {
+    return MINIMUM_REQUIRED_POSITIONS.keySet().stream()
+        .anyMatch(positionType -> matchingList.stream()
+            .noneMatch(m -> m.getPosition().getType().equals(positionType)));
+  }
+
+  public boolean isNotEnough(PositionType positionType) {
+    return matchingList.stream()
+        .filter(m -> m.getPosition().getType().equals(positionType))
+        .count() < MINIMUM_REQUIRED_POSITIONS.get(positionType);
+  }
+
+  //현재 포지션이 다른 포지션의 최대 인원수보다 2배이상 많으면 안된다.
+  //MAXIMUM_POSITIONS에 제한된 인원수를 넘으면 안된다.
+  public boolean isCanInsertPosition(PositionType positionType) {
+
+    var otherPositionMinSize = matchingList.stream()
+        .filter(m -> !m.getPosition().getType().equals(positionType))
+        .collect(groupingBy(matching -> matching.getPosition().getType()))
+        .values().stream().map(List::size).min(Integer::compareTo).orElse(0);
+
+    var limitSize = Math.min(
+        otherPositionMinSize * MULTIPLE_POSITION_COMPARE_TO_OTHER_POSITIONS.get(positionType),
+        MAXIMUM_POSITIONS.get(positionType)
+    );
+
+    var nowSize = matchingList.stream()
+        .filter(m -> m.getPosition().getType().equals(positionType))
+        .count();
+
+    return nowSize < limitSize;
+  }
+
+  //플래너와 디자이너는 필요한 스킬이 없다.
+  //백엔드와 프론트엔드는 기존에 있는 사람과 skill이 일치하는 것이 존재해야 한다.
+  public List<Long> getRequiredSkillIds(PositionType positionType) {
+    if (PositionType.PLANNER.equals(positionType) || PositionType.DESIGNER.equals(positionType)) {
+      return List.of();
+    }
+    return matchingList.stream()
+        .filter(m -> m.getPosition().getType().equals(positionType))
+        .map(m -> m.getUser().getUserInfo().getUserInfoSkills())
+        .flatMap(List::stream)
+        .map(UserInfoSkill::getSkill)
+        .distinct()
+        .filter(skill -> skill.getSkillSets().stream()
+            .anyMatch(skillSet -> skillSet.getPosition().getType().equals(positionType)))
+        .map(Skill::getId)
+        .toList();
+  }
+
+  public void addMatching(Matching matching) {
+    matchingList.add(matching);
+    matching.match(this);
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -45,8 +45,8 @@ public class MatchingRoom extends BaseTimeEntity {
   @Column(name = "chat_room_id", nullable = false)
   private Long chatRoomId;
 
-  @Column(name = "is_complete", nullable = false)
-  private Boolean isComplete;
+  @Column(name = "is_completed", nullable = false)
+  private Boolean isCompleted;
 
   @Column(name = "completed_at", nullable = true)
   private LocalDateTime completedAt;
@@ -63,7 +63,7 @@ public class MatchingRoom extends BaseTimeEntity {
     }
     var newMatchingRoom =  MatchingRoom.builder()
         .chatRoomId(chatRoomId)
-        .isComplete(false)
+        .isCompleted(false)
         .completedAt(null)
         .hostUserId(matchingList.stream()
             .filter(m -> PositionType.PLANNER.equals(m.getPosition().getType())).findFirst()
@@ -158,7 +158,7 @@ public class MatchingRoom extends BaseTimeEntity {
   }
 
   public void complete() {
-    isComplete = true;
+    isCompleted = true;
     completedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -1,9 +1,9 @@
 package org.crops.fitserver.domain.matching.entity;
 
 import static java.util.stream.Collectors.groupingBy;
-import static org.crops.fitserver.domain.matching.constant.Constant.MAXIMUM_POSITIONS;
-import static org.crops.fitserver.domain.matching.constant.Constant.MINIMUM_REQUIRED_POSITIONS;
-import static org.crops.fitserver.domain.matching.constant.Constant.MULTIPLE_POSITION_COMPARE_TO_OTHER_POSITIONS;
+import static org.crops.fitserver.domain.matching.constant.MatchingConstants.MAXIMUM_POSITIONS;
+import static org.crops.fitserver.domain.matching.constant.MatchingConstants.MINIMUM_REQUIRED_POSITIONS;
+import static org.crops.fitserver.domain.matching.constant.MatchingConstants.MULTIPLE_POSITION_COMPARE_TO_OTHER_POSITIONS;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -1,0 +1,46 @@
+package org.crops.fitserver.domain.matching.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.crops.fitserver.global.entity.BaseTimeEntity;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Where(clause = "is_deleted = false")
+public class MatchingRoom extends BaseTimeEntity {
+  @Id
+  @Column(name = "matching_room_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "chat_room_id", nullable = false)
+  private Long chatRoomId;
+
+  @Column(name = "is_matched", nullable = false)
+  private Boolean isMatched;
+
+  @Column(name = "matched_at", nullable = true)
+  private Long matchedAt;
+
+  @Column(name = "host_user_id", nullable = false)
+  private Long hostUserId;
+
+  @OneToMany(mappedBy = "matchingRoom")
+  private List<Matching> matchings;
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,17 +14,20 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
+import org.crops.fitserver.global.exception.BusinessException;
+import org.crops.fitserver.global.exception.ErrorCode;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PROTECTED)
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Where(clause = "is_deleted = false")
 public class MatchingRoom extends BaseTimeEntity {
+
   @Id
   @Column(name = "matching_room_id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,5 +46,44 @@ public class MatchingRoom extends BaseTimeEntity {
   private Long hostUserId;
 
   @OneToMany(mappedBy = "matchingRoom")
-  private List<Matching> matchings;
+  private List<Matching> matchingList = new ArrayList<>();
+
+  public static MatchingRoom createRoom(List<Matching> matchingList, Long chatRoomId) {
+    if (matchingList.stream().map(Matching::getPosition).distinct().count() < 4) {
+      throw new BusinessException(ErrorCode.NOT_ENOUGH_MATCHING_EXCEPTION);
+    }
+    return MatchingRoom.builder()
+        .matchingList(matchingList)
+        .chatRoomId(chatRoomId)
+        .isMatched(false)
+        .matchedAt(null)
+        .hostUserId(matchingList.get(0).getUser().getId())
+        .build();
+  }
+
+  public void forceOut(Long userId, Long forceOutUserId) {
+    if (!hostUserId.equals(userId)) {
+      throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION);
+    }
+    if (forceOutUserId.equals(userId)) {
+      throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION);
+    }
+
+    var matching = matchingList.stream()
+        .filter(m -> m.getUser().getId().equals(forceOutUserId))
+        .findFirst()
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+
+    matching.cancel();
+  }
+
+  public void changeHost() {
+    //현재 호스트를 제외하고 완전 랜덤하게 호스트 변경
+    var newHost = matchingList.stream()
+        .filter(m -> !m.getUser().getId().equals(hostUserId))
+        .findAny()
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+
+    hostUserId = newHost.getUser().getId();
+  }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -66,7 +66,10 @@ public class MatchingRoom extends BaseTimeEntity {
         .chatRoomId(chatRoomId)
         .isComplete(false)
         .completedAt(null)
-        .hostUserId(matchingList.get(0).getUser().getId())
+        .hostUserId(matchingList.stream()
+            .filter(m -> PositionType.PLANNER.equals(m.getPosition().getType())).findFirst()
+            .orElse(matchingList.get(0))
+            .getUser().getId())
         .build();
   }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -154,4 +154,9 @@ public class MatchingRoom extends BaseTimeEntity {
     matchingList.add(matching);
     matching.match(this);
   }
+
+  public void complete() {
+    isComplete = true;
+    completedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -55,14 +55,13 @@ public class MatchingRoom extends BaseTimeEntity {
   private Long hostUserId;
 
   @OneToMany(mappedBy = "matchingRoom")
-  private List<Matching> matchingList = new ArrayList<>();
+  private final List<Matching> matchingList = new ArrayList<>();
 
   public static MatchingRoom createRoom(List<Matching> matchingList, Long chatRoomId) {
     if (matchingList.stream().map(Matching::getPosition).distinct().count() < 4) {
       throw new BusinessException(ErrorCode.NOT_ENOUGH_MATCHING_EXCEPTION);
     }
-    return MatchingRoom.builder()
-        .matchingList(matchingList)
+    var newMatchingRoom =  MatchingRoom.builder()
         .chatRoomId(chatRoomId)
         .isComplete(false)
         .completedAt(null)
@@ -71,6 +70,9 @@ public class MatchingRoom extends BaseTimeEntity {
             .orElse(matchingList.get(0))
             .getUser().getId())
         .build();
+    matchingList.forEach(newMatchingRoom::addMatching);
+
+    return newMatchingRoom;
   }
 
   public void forceOut(Long userId, Long forceOutUserId) {

--- a/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/entity/MatchingRoom.java
@@ -53,7 +53,7 @@ public class MatchingRoom extends BaseTimeEntity {
   @Column(name = "host_user_id", nullable = false)
   private Long hostUserId;
 
-  public static MatchingRoom createRoom(List<Matching> matchingList, Long chatRoomId) {
+  public static MatchingRoom create(List<Matching> matchingList, Long chatRoomId) {
     if (matchingList.stream().map(Matching::getPosition).distinct().count() < 4) {
       throw new BusinessException(ErrorCode.NOT_ENOUGH_MATCHING_EXCEPTION);
     }
@@ -61,14 +61,19 @@ public class MatchingRoom extends BaseTimeEntity {
         .chatRoomId(chatRoomId)
         .isCompleted(false)
         .completedAt(null)
-        .hostUserId(matchingList.stream()
-            .filter(m -> PositionType.PLANNER.equals(m.getPosition().getType())).findFirst()
-            .orElse(matchingList.get(0))
-            .getUser().getId())
+        .hostUserId(selectHostUserId(matchingList))
         .build();
     matchingList.forEach(newMatchingRoom::addMatching);
 
     return newMatchingRoom;
+  }
+
+  private static Long selectHostUserId(List<Matching> matchingList) {
+    return matchingList.stream()
+        .filter(m -> PositionType.PLANNER.equals(m.getPosition().getType()))
+        .findFirst()
+        .orElse(matchingList.get(0))
+        .getUser().getId();
   }
 
   public void forceOut(Long userId, Long forceOutUserId) {
@@ -109,6 +114,18 @@ public class MatchingRoom extends BaseTimeEntity {
         .count() < MINIMUM_REQUIRED_POSITIONS.get(positionType);
   }
 
+  public boolean isCanJoinRoom(Matching matching, PositionType positionType) {
+    return isCanInsertPosition(positionType) &&
+        getRequiredPositionId(positionType)
+            .orElse(matching.getPosition().getId())
+            .equals(matching.getPosition().getId()) &&
+        getRequiredSkillIds(positionType).retainAll(
+            matching.getUser().getUserInfo()
+                .getUserInfoSkills().stream()
+                .map(userInfoSkill -> userInfoSkill.getSkill().getId()).toList()
+        );
+  }
+
   //현재 포지션이 다른 포지션의 최대 인원수보다 2배이상 많으면 안된다.
   //MAXIMUM_POSITIONS에 제한된 인원수를 넘으면 안된다.
   public boolean isCanInsertPosition(PositionType positionType) {
@@ -130,6 +147,17 @@ public class MatchingRoom extends BaseTimeEntity {
     return nowSize < limitSize;
   }
 
+  //백엔드와 프론트엔드는 포지션 id까지 일치해야 한다.
+  public Optional<Long> getRequiredPositionId(PositionType positionType) {
+    if(PositionType.PLANNER.equals(positionType) || PositionType.DESIGNER.equals(positionType)) {
+      return Optional.empty();
+    }
+    return matchingList.stream()
+        .filter(m -> m.getPosition().getType().equals(positionType))
+        .map(m -> m.getPosition().getId())
+        .findFirst();
+  }
+
   //플래너와 디자이너는 필요한 스킬이 없다.
   //백엔드와 프론트엔드는 기존에 있는 사람과 skill이 일치하는 것이 존재해야 한다.
   public List<Long> getRequiredSkillIds(PositionType positionType) {
@@ -143,7 +171,7 @@ public class MatchingRoom extends BaseTimeEntity {
         .map(UserInfoSkill::getSkill)
         .distinct()
         .filter(skill -> skill.getSkillSets().stream()
-            .anyMatch(skillSet -> skillSet.getPosition().getType().equals(positionType)))
+            .anyMatch(skillSet -> skillSet.isEqualPositionType(positionType)))
         .map(Skill::getId)
         .toList();
   }
@@ -161,17 +189,5 @@ public class MatchingRoom extends BaseTimeEntity {
     isCompleted = true;
     completedAt = LocalDateTime.now();
     matchingList.forEach(Matching::complete);
-  }
-
-
-  //백엔드와 프론트엔드는 포지션 id까지 일치해야 한다.
-  public Optional<Long> getRequiredPositionId(PositionType positionType) {
-    if(PositionType.PLANNER.equals(positionType) || PositionType.DESIGNER.equals(positionType)) {
-      return Optional.empty();
-    }
-    return matchingList.stream()
-        .filter(m -> m.getPosition().getType().equals(positionType))
-        .map(m -> m.getPosition().getId())
-        .findFirst();
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
@@ -21,4 +21,10 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
       + "where m.expiredAt <= current_timestamp "
       + "and m.isDeleted = false")
   List<Matching> findExpireMatching();
+
+  @Query("select m from Matching m "
+      + "where m.status = 'WAITING'"
+      + "and m.matchingRoom is null "
+      + "and m.isDeleted = false")
+  List<Matching> findMatchingWithoutRoom();
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
@@ -2,11 +2,11 @@ package org.crops.fitserver.domain.matching.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 import org.crops.fitserver.domain.matching.entity.Matching;
 import org.crops.fitserver.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
@@ -16,4 +16,9 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
       + "and (m.expiredAt is null or m.expiredAt > current_timestamp) "
       + "and m.isDeleted = false")
   Optional<Matching> findActiveMatchingByUser(User user, List<MatchingStatus> statusList);
+
+  @Query("select m from Matching m "
+      + "where m.expiredAt <= current_timestamp "
+      + "and m.isDeleted = false")
+  List<Matching> findExpireMatching();
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
@@ -15,7 +15,7 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
       + "and m.status in :statusList "
       + "and (m.expiredAt is null or m.expiredAt > current_timestamp) "
       + "and m.isDeleted = false")
-  Optional<Matching> findActiveMatchingByUser(User user, List<MatchingStatus> statusList);
+  Optional<Matching> findActiveMatchingByUserAndStatus(User user, List<MatchingStatus> statusList);
 
   @Query("select m from Matching m "
       + "where m.expiredAt <= current_timestamp "

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRepository.java
@@ -1,0 +1,19 @@
+package org.crops.fitserver.domain.matching.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.crops.fitserver.domain.matching.entity.Matching;
+import org.crops.fitserver.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.crops.fitserver.domain.matching.constant.MatchingStatus;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+
+  @Query("select m from Matching m "
+      + "where m.user = :user "
+      + "and m.status in :statusList "
+      + "and (m.expiredAt is null or m.expiredAt > current_timestamp) "
+      + "and m.isDeleted = false")
+  Optional<Matching> findActiveMatchingByUser(User user, List<MatchingStatus> statusList);
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
@@ -1,0 +1,8 @@
+package org.crops.fitserver.domain.matching.repository;
+
+import org.crops.fitserver.domain.matching.entity.MatchingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
 
   @Query("select mr from MatchingRoom mr "
-      + "where mr.isComplete = false "
+      + "where mr.isCompleted = false "
       + "and mr.isDeleted = false")
   List<MatchingRoom> findMatchingRoomNotComplete();
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
@@ -1,6 +1,7 @@
 package org.crops.fitserver.domain.matching.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,10 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
       + "where mr.isCompleted = false "
       + "and mr.isDeleted = false")
   List<MatchingRoom> findMatchingRoomNotComplete();
+
+  @Query("select mr from MatchingRoom mr "
+      + "join fetch mr.matchingList ml "
+      + "join fetch ml.user u "
+      + "where mr.id = :id")
+  Optional<MatchingRoom> findWithMatchingMembersById(Long id);
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/repository/MatchingRoomRepository.java
@@ -1,8 +1,14 @@
 package org.crops.fitserver.domain.matching.repository;
 
+import java.util.List;
 import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
 
+  @Query("select mr from MatchingRoom mr "
+      + "where mr.isComplete = false "
+      + "and mr.isDeleted = false")
+  List<MatchingRoom> findMatchingRoomNotComplete();
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
@@ -1,4 +1,4 @@
-package org.crops.fitserver.domain.matching.batch;
+package org.crops.fitserver.domain.matching.scheduler;
 
 
 import static java.util.stream.Collectors.groupingBy;

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
@@ -22,7 +22,6 @@ public class MatchingProcessor {
   private final MatchingRepository matchingRepository;
   private final MatchingRoomRepository matchingRoomRepository;
   private final ChatRoomService chatRoomService;
-  private List<Matching> matchingList;
   private List<MatchingRoom> matchingRoomList;
 
   private Map<PositionType, List<Matching>> matchingMap;
@@ -37,11 +36,12 @@ public class MatchingProcessor {
   }
 
   private void init() {
-    matchingList = matchingRepository.findMatchingWithoutRoom();
-    matchingRoomList = matchingRoomRepository.findMatchingRoomNotComplete();
+    List<Matching> matchingList = matchingRepository.findMatchingWithoutRoom();
 
     matchingMap = matchingList.stream()
         .collect(groupingBy(matching -> matching.getPosition().getType()));
+
+    matchingRoomList = matchingRoomRepository.findMatchingRoomNotComplete();
 
     //매칭 만료 시간 순으로 정렬
     matchingMap.forEach((key, value) -> {

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
@@ -17,6 +17,10 @@ import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
 import org.crops.fitserver.domain.skillset.constant.PositionType;
 import org.springframework.transaction.annotation.Transactional;
 
+
+/**
+ * TODO: 싱글턴으로 전환
+ */
 public class MatchingProcessor {
 
   private final MatchingRepository matchingRepository;
@@ -127,6 +131,9 @@ public class MatchingProcessor {
     return matchingList.size();
   }
 
+  /**
+   * 최소한의 필터
+   */
   private List<MatchingRoom> filterEnableRoomList(Matching matching, List<MatchingRoom> roomList,
       PositionType positionType) {
     return roomList.stream()

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingProcessor.java
@@ -132,6 +132,9 @@ public class MatchingProcessor {
         .toList();
   }
 
+  /**
+   * TODO: 최적의 매칭 방을 찾아서 반환
+   * */
   private Optional<MatchingRoom> findBestRoom(List<MatchingRoom> roomList, Matching matching, PositionType positionType) {
     return roomList.stream()
         .filter(matchingRoom -> isCanJoinRoom(matching, matchingRoom, positionType))

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingScheduler.java
@@ -1,4 +1,4 @@
-package org.crops.fitserver.domain.matching.batch;
+package org.crops.fitserver.domain.matching.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingScheduler.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/scheduler/MatchingScheduler.java
@@ -31,9 +31,9 @@ public class MatchingScheduler {
 
     long matchingCount = 0;
 
-    matchingCount += matchingProcessor.insertToNotEnoughRoom();
-    matchingCount += matchingProcessor.createNewRoom();
-    matchingCount += matchingProcessor.joinRoom();
+    matchingProcessor.insertToNotEnoughRoom();
+    matchingProcessor.createNewRoom();
+    matchingProcessor.joinRoom();
 
     log.info("매칭 종료 : {}개 매칭", matchingCount);
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -1,16 +1,15 @@
 package org.crops.fitserver.domain.matching.service;
 
 import java.util.List;
-import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
-import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
 
 public interface MatchingService {
 
-  CreateMatchingResponse createMatching(Long userId);
+  MatchingDto createMatching(Long userId);
 
-  GetMatchingResponse getMatching(Long userId);
+  MatchingDto getMatching(Long userId);
 
   void cancel(Long userId);
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -1,0 +1,16 @@
+package org.crops.fitserver.domain.matching.service;
+
+import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
+
+public interface MatchingService {
+
+  CreateMatchingResponse createMatching(Long userId);
+
+  GetMatchingResponse getMatching(Long userId);
+
+  GetMatchingRoomResponse getMatchingRoom(Long userId, Long roomId);
+  void cancelMatching(Long userId);
+
+}

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -12,13 +12,15 @@ public interface MatchingService {
 
   GetMatchingResponse getMatching(Long userId);
 
+  void cancel(Long userId);
+
   GetMatchingRoomResponse getMatchingRoom(Long userId, Long roomId);
 
-  void readyMatching(Long userId, Long roomId);
+  void ready(Long userId, Long roomId);
 
-  void completeMatching(Long userId, Long roomId);
+  void complete(Long userId, Long roomId);
 
-  void cancelMatching(Long userId);
+  void exit(Long userId, Long roomId);
 
   List<Matching> expireMatchingAll();
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -1,8 +1,10 @@
 package org.crops.fitserver.domain.matching.service;
 
+import java.util.List;
 import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
+import org.crops.fitserver.domain.matching.entity.Matching;
 
 public interface MatchingService {
 
@@ -11,6 +13,10 @@ public interface MatchingService {
   GetMatchingResponse getMatching(Long userId);
 
   GetMatchingRoomResponse getMatchingRoom(Long userId, Long roomId);
+
   void cancelMatching(Long userId);
 
+  List<Matching> expireMatchingAll();
+
+  void forceOut(Long userId, Long roomId, Long forceOutUserId);
 }

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -14,6 +14,8 @@ public interface MatchingService {
 
   GetMatchingRoomResponse getMatchingRoom(Long userId, Long roomId);
 
+  void completeMatching(Long userId, Long roomId);
+
   void cancelMatching(Long userId);
 
   List<Matching> expireMatchingAll();

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -14,6 +14,8 @@ public interface MatchingService {
 
   GetMatchingRoomResponse getMatchingRoom(Long userId, Long roomId);
 
+  void readyMatching(Long userId, Long roomId);
+
   void completeMatching(Long userId, Long roomId);
 
   void cancelMatching(Long userId);

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -5,7 +5,6 @@ import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
-import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
 public interface MatchingService {
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/MatchingService.java
@@ -5,6 +5,7 @@ import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
+import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 
 public interface MatchingService {
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -65,7 +65,7 @@ public class MatchingServiceImpl implements MatchingService {
     if (!Objects.equals(matching.getMatchingRoom().getId(), roomId)) {
       throw new BusinessException(ErrorCode.NOT_EXIST_MATCHING_ROOM_EXCEPTION);
     }
-    var matchingRoom = matchingRoomRepository.findById(roomId)
+    var matchingRoom = matchingRoomRepository.findWithMatchingMembersById(roomId)
         .orElseThrow(() -> new BusinessException(
             ErrorCode.NOT_EXIST_MATCHING_ROOM_EXCEPTION));
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -10,7 +10,6 @@ import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
-import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 import org.crops.fitserver.domain.matching.repository.MatchingRepository;
 import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
 import org.crops.fitserver.domain.matching.service.MatchingService;

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -63,7 +63,7 @@ public class MatchingServiceImpl implements MatchingService {
         ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
 
     if (!Objects.equals(matching.getMatchingRoom().getId(), roomId)) {
-      throw new BusinessException(ErrorCode.NOT_EXIST_MATCHING_EXCEPTION);
+      throw new BusinessException(ErrorCode.Not_EXIST_MATCHING_ROOM_EXCEPTION);
     }
     var matchingRoom = matching.getMatchingRoom();
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -6,8 +6,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.matching.constant.MatchingStatus;
-import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
-import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
 import org.crops.fitserver.domain.matching.repository.MatchingRepository;
@@ -31,7 +30,7 @@ public class MatchingServiceImpl implements MatchingService {
 
   @Override
   @Transactional
-  public CreateMatchingResponse createMatching(Long userId) {
+  public MatchingDto createMatching(Long userId) {
     var user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
     //이미 매칭이 존재한다면 에러 발생.
@@ -40,18 +39,18 @@ public class MatchingServiceImpl implements MatchingService {
     }
 
     var matching = matchingRepository.save(Matching.create(user));
-    return CreateMatchingResponse.from(matching);
+    return MatchingDto.from(matching);
   }
 
   @Override
   @Transactional(readOnly = true)
-  public GetMatchingResponse getMatching(Long userId) {
+  public MatchingDto getMatching(Long userId) {
     var user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
     var matching = getActiveMatching(user).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
 
-    return GetMatchingResponse.from(matching);
+    return MatchingDto.from(matching);
   }
 
   @Override
@@ -122,7 +121,7 @@ public class MatchingServiceImpl implements MatchingService {
     var matching = getActiveMatching(user).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
     var matchingRoom = matching.getMatchingRoom();
-    if(!Objects.equals(matchingRoom.getId(), roomId)){
+    if (!Objects.equals(matchingRoom.getId(), roomId)) {
       throw new BusinessException(ErrorCode.NOT_EXIST_MATCHING_ROOM_EXCEPTION);
     }
 

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -72,6 +72,28 @@ public class MatchingServiceImpl implements MatchingService {
 
   @Override
   @Transactional
+  public void completeMatching(Long userId, Long roomId) {
+    var user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));
+    var matching = getActiveMatching(user).orElseThrow(() -> new BusinessException(
+        ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+    var matchingRoom = matching.getMatchingRoom();
+
+    if (!Objects.equals(matchingRoom.getId(), roomId)) {
+      throw new BusinessException(ErrorCode.NOT_EXIST_MATCHING_EXCEPTION);
+    }
+    if (!Objects.equals(matchingRoom.getHostUserId(), userId)) {
+      throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION);
+    }
+
+    matchingRoom.complete();
+    matchingRoomRepository.save(matchingRoom);
+
+    //TODO: 내 프로젝트 생성 로직 추가
+  }
+
+  @Override
+  @Transactional
   public void cancelMatching(Long userId) {
     var user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(
         ErrorCode.NOT_FOUND_RESOURCE_EXCEPTION));

--- a/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
+++ b/src/main/java/org/crops/fitserver/domain/matching/service/impl/MatchingServiceImpl.java
@@ -10,6 +10,7 @@ import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.entity.Matching;
+import org.crops.fitserver.domain.matching.entity.MatchingRoom;
 import org.crops.fitserver.domain.matching.repository.MatchingRepository;
 import org.crops.fitserver.domain.matching.repository.MatchingRoomRepository;
 import org.crops.fitserver.domain.matching.service.MatchingService;

--- a/src/main/java/org/crops/fitserver/domain/skillset/constant/PositionType.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/constant/PositionType.java
@@ -1,0 +1,5 @@
+package org.crops.fitserver.domain.skillset.constant;
+
+public enum PositionType {
+  PLANNER, DESIGNER, BACKEND, FRONTEND
+}

--- a/src/main/java/org/crops/fitserver/domain/skillset/domain/Position.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/domain/Position.java
@@ -5,6 +5,8 @@ import static jakarta.persistence.CascadeType.ALL;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.crops.fitserver.domain.skillset.constant.PositionType;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
@@ -44,6 +47,10 @@ public class Position extends BaseTimeEntity {
 
   @Column(nullable = false)
   private String imageUrl;
+
+  @Column(nullable = true)//마이그레이션을 위해 null 허용
+  @Enumerated(EnumType.STRING)
+  private PositionType type;
 
   public void updateDisplayName(String displayName) {
     this.displayName = displayName;

--- a/src/main/java/org/crops/fitserver/domain/skillset/domain/SkillSet.java
+++ b/src/main/java/org/crops/fitserver/domain/skillset/domain/SkillSet.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.crops.fitserver.domain.skillset.constant.PositionType;
 
 @Entity
 @Table(name = "skillset")
@@ -41,5 +42,9 @@ public class SkillSet {
         .skill(skill)
         .position(position)
         .build();
+  }
+
+  public boolean isEqualPositionType(PositionType positionType) {
+    return this.position.getType().equals(positionType);
   }
 }

--- a/src/main/java/org/crops/fitserver/domain/user/domain/User.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/User.java
@@ -114,9 +114,7 @@ public class User extends BaseTimeEntity {
   }
 
   public void promoteRole(UserRole userRole) {
-    if (this.userRole.compareTo(userRole) < 0) {
       this.userRole = userRole;
-    }
   }
 }
 

--- a/src/main/java/org/crops/fitserver/domain/user/domain/User.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/User.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 import org.crops.fitserver.global.entity.BaseTimeEntity;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-import org.openapitools.jackson.nullable.JsonNullable;
 
 @Entity
 @Getter
@@ -112,6 +111,12 @@ public class User extends BaseTimeEntity {
     }
     this.email = email;
     return this;
+  }
+
+  public void promoteRole(UserRole userRole) {
+    if (this.userRole.compareTo(userRole) < 0) {
+      this.userRole = userRole;
+    }
   }
 }
 

--- a/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
@@ -102,7 +102,7 @@ public class UserInfo extends BaseTimeEntity {
   @PrePersist
   public void prePersist() {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
-    if(this.isReadyToComplete()){
+    if (this.isReadyToComplete()) {
       this.user.promoteRole(UserRole.MEMBER);
     }
   }
@@ -110,7 +110,7 @@ public class UserInfo extends BaseTimeEntity {
   @PreUpdate
   public void preUpdate() {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
-    if(this.isReadyToComplete()){
+    if (this.isReadyToComplete()) {
       this.user.promoteRole(UserRole.MEMBER);
     }
   }
@@ -146,7 +146,7 @@ public class UserInfo extends BaseTimeEntity {
   }
 
   public UserInfo withLinkJson(String linkJson) {
-    if (StringUtils.isNotBlank(this.linkJson) &&StringUtils.isBlank(linkJson)) {
+    if (StringUtils.isNotBlank(this.linkJson) && StringUtils.isBlank(linkJson)) {
       throw new IllegalArgumentException("linkJson cannot be null");
     }
     this.linkJson = linkJson;
@@ -222,7 +222,12 @@ public class UserInfo extends BaseTimeEntity {
   }
 
   public UserInfo withSkills(List<Skill> skillList) {
-    skillList.forEach(this::addSkill);
+    skillList.stream().filter(
+        skill -> this.userInfoSkills.stream()
+            .noneMatch(userInfoSkill -> userInfoSkill.getSkill().equals(skill))
+    ).forEach(this::addSkill);
+    this.userInfoSkills.removeIf(userInfoSkill -> skillList.stream()
+        .noneMatch(skill -> userInfoSkill.getSkill().equals(skill)));
 
     return this;
   }

--- a/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
@@ -101,17 +101,23 @@ public class UserInfo extends BaseTimeEntity {
 
   @PrePersist
   public void prePersist() {
-    this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
-    if (this.isReadyToComplete()) {
-      this.user.promoteRole(UserRole.MEMBER);
-    }
+    this.updateUserIfEssentialFieldsFilled();
   }
 
   @PreUpdate
   public void preUpdate() {
-    this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
-    if (this.isReadyToComplete()) {
+    this.updateUserIfEssentialFieldsFilled();
+  }
+
+  public void updateUserIfEssentialFieldsFilled() {
+    if (this.isEssentialFieldsFilled()) {
+      this.status = UserInfoStatus.COMPLETE;
       this.user.promoteRole(UserRole.MEMBER);
+    } else {
+      this.status = UserInfoStatus.INCOMPLETE;
+      if(UserRole.MEMBER.equals(this.user.getUserRole())) {
+        this.user.promoteRole(UserRole.NON_MEMBER);
+      }
     }
   }
 
@@ -236,7 +242,7 @@ public class UserInfo extends BaseTimeEntity {
     this.userInfoSkills.removeIf(userInfoSkill -> userInfoSkill.getSkill().equals(skill));
   }
 
-  private boolean isReadyToComplete() {
+  private boolean isEssentialFieldsFilled() {
     return this.projectCount != null
         && this.activityHour != null
         && this.introduce != null

--- a/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
+++ b/src/main/java/org/crops/fitserver/domain/user/domain/UserInfo.java
@@ -102,11 +102,17 @@ public class UserInfo extends BaseTimeEntity {
   @PrePersist
   public void prePersist() {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
+    if(this.isReadyToComplete()){
+      this.user.promoteRole(UserRole.MEMBER);
+    }
   }
 
   @PreUpdate
   public void preUpdate() {
     this.status = this.isReadyToComplete() ? UserInfoStatus.COMPLETE : UserInfoStatus.INCOMPLETE;
+    if(this.isReadyToComplete()){
+      this.user.promoteRole(UserRole.MEMBER);
+    }
   }
 
 

--- a/src/main/java/org/crops/fitserver/domain/user/dto/PolicyAgreementDto.java
+++ b/src/main/java/org/crops/fitserver/domain/user/dto/PolicyAgreementDto.java
@@ -1,6 +1,7 @@
 package org.crops.fitserver.domain.user.dto;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import org.crops.fitserver.domain.user.constant.PolicyType;
 import org.crops.fitserver.domain.user.domain.UserPolicyAgreement;
@@ -10,7 +11,7 @@ public record PolicyAgreementDto(
     @NotNull PolicyType policyType,
     @NotNull String version,
     @NotNull Boolean isAgree,
-    String updatedAt
+    LocalDateTime updatedAt
 ) {
 
   public static PolicyAgreementDto from(UserPolicyAgreement userPolicyAgreement) {
@@ -18,12 +19,12 @@ public record PolicyAgreementDto(
         .policyType(userPolicyAgreement.getPolicyType())
         .version(userPolicyAgreement.getVersion())
         .isAgree(userPolicyAgreement.getIsAgree())
-        .updatedAt(userPolicyAgreement.getUpdatedAt().toString())
+        .updatedAt(userPolicyAgreement.getUpdatedAt())
         .build();
   }
 
   public static PolicyAgreementDto of(PolicyType policyType, String version, Boolean isAgree,
-      String UpdatedAt) {
+      LocalDateTime UpdatedAt) {
     return new PolicyAgreementDto(policyType, version, isAgree, UpdatedAt);
   }
 }

--- a/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
@@ -3,11 +3,7 @@ package org.crops.fitserver.global.config;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -26,17 +22,17 @@ public class ObjectMapperConfig {
       builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
       builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-      final SimpleModule localDateTimeModule = new SimpleModule();
-      localDateTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(
-          DateTimeFormatter.ISO_DATE_TIME));
-      localDateTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(
-          DateTimeFormatter.ISO_DATE_TIME));
-      builder.modules(jsonNullableModule(), localDateTimeModule);
+      builder.modules(jsonNullableModule(), javaTimeModule());
     };
   }
 
   @Bean
   public JsonNullableModule jsonNullableModule() {
     return new JsonNullableModule();
+  }
+
+  @Bean
+  public JavaTimeModule javaTimeModule(){
+    return new JavaTimeModule();
   }
 }

--- a/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/org/crops/fitserver/global/config/ObjectMapperConfig.java
@@ -3,6 +3,11 @@ package org.crops.fitserver.global.config;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +25,13 @@ public class ObjectMapperConfig {
       builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
       builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
       builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-      builder.modules(jsonNullableModule());
+
+      final SimpleModule localDateTimeModule = new SimpleModule();
+      localDateTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(
+          DateTimeFormatter.ISO_DATE_TIME));
+      localDateTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(
+          DateTimeFormatter.ISO_DATE_TIME));
+      builder.modules(jsonNullableModule(), localDateTimeModule);
     };
   }
 

--- a/src/main/java/org/crops/fitserver/global/config/SchedulingConfig.java
+++ b/src/main/java/org/crops/fitserver/global/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package org.crops.fitserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
@@ -54,8 +54,8 @@ public enum ErrorCode {
    */
   ALREADY_EXIST_MATCHING_EXCEPTION(HttpStatus.CONFLICT, "matching-1", "이미 매칭이 존재합니다."),
   NOT_EXIST_MATCHING_EXCEPTION(HttpStatus.NOT_FOUND, "matching-2", "매칭이 존재하지 않습니다."),
-
-  NOT_ENOUGH_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-3", "매칭이 충분하지 않습니다."),
+  Not_EXIST_MATCHING_ROOM_EXCEPTION(HttpStatus.NOT_FOUND, "matching-3", "매칭 방이 존재하지 않습니다."),
+  NOT_ENOUGH_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-4", "매칭 인원 수가 충분하지 않습니다."),
   ;
 
 

--- a/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
   NOT_ENOUGH_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-4", "매칭 인원 수가 충분하지 않습니다."),
   NOT_READY_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-5", "모든 인원이 매칭 준비가 되지 않았습니다."),
   NOT_ENABLE_READY_EXCEPTION(HttpStatus.FORBIDDEN, "matching-6", "임시 방장은 준비할 수 없습니다."),
+  ALREADY_EXIST_MATCHING_ROOM_EXCEPTION(HttpStatus.CONFLICT, "matching-7", "이미 매칭방이 존재합니다."),
   ;
 
 

--- a/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
@@ -48,7 +48,12 @@ public enum ErrorCode {
    */
   DUPLICATED_POLICY_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "user-policy-agreement-1", "같은 약관을 한 번에 여러 번 동의할 수 없습니다."),
 
-
+  //matching
+  /**
+   * matching. code prefix: matching-
+   */
+  ALREADY_EXIST_MATCHING_EXCEPTION(HttpStatus.CONFLICT, "matching-1", "이미 매칭이 존재합니다."),
+  NOT_EXIST_MATCHING_EXCEPTION(HttpStatus.NOT_FOUND, "matching-2", "매칭이 존재하지 않습니다."),
 
   ;
 

--- a/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
@@ -42,11 +42,11 @@ public enum ErrorCode {
    */
   FILE_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "file-1", "파일 업로드에 실패했습니다."),
 
-
   /**
    * user-policy-agreement. code prefix: user-policy-agreement-
    */
-  DUPLICATED_POLICY_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "user-policy-agreement-1", "같은 약관을 한 번에 여러 번 동의할 수 없습니다."),
+  DUPLICATED_POLICY_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "user-policy-agreement-1",
+      "같은 약관을 한 번에 여러 번 동의할 수 없습니다."),
 
   //matching
   /**
@@ -55,8 +55,8 @@ public enum ErrorCode {
   ALREADY_EXIST_MATCHING_EXCEPTION(HttpStatus.CONFLICT, "matching-1", "이미 매칭이 존재합니다."),
   NOT_EXIST_MATCHING_EXCEPTION(HttpStatus.NOT_FOUND, "matching-2", "매칭이 존재하지 않습니다."),
 
+  NOT_ENOUGH_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-3", "매칭이 충분하지 않습니다."),
   ;
-
 
 
   private final HttpStatus httpStatus;

--- a/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/crops/fitserver/global/exception/ErrorCode.java
@@ -54,8 +54,10 @@ public enum ErrorCode {
    */
   ALREADY_EXIST_MATCHING_EXCEPTION(HttpStatus.CONFLICT, "matching-1", "이미 매칭이 존재합니다."),
   NOT_EXIST_MATCHING_EXCEPTION(HttpStatus.NOT_FOUND, "matching-2", "매칭이 존재하지 않습니다."),
-  Not_EXIST_MATCHING_ROOM_EXCEPTION(HttpStatus.NOT_FOUND, "matching-3", "매칭 방이 존재하지 않습니다."),
+  NOT_EXIST_MATCHING_ROOM_EXCEPTION(HttpStatus.NOT_FOUND, "matching-3", "매칭 방이 존재하지 않습니다."),
   NOT_ENOUGH_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-4", "매칭 인원 수가 충분하지 않습니다."),
+  NOT_READY_MATCHING_EXCEPTION(HttpStatus.NOT_ACCEPTABLE, "matching-5", "모든 인원이 매칭 준비가 되지 않았습니다."),
+  NOT_ENABLE_READY_EXCEPTION(HttpStatus.FORBIDDEN, "matching-6", "임시 방장은 준비할 수 없습니다."),
   ;
 
 

--- a/src/main/resources/db/mariadb/V1_init.sql
+++ b/src/main/resources/db/mariadb/V1_init.sql
@@ -135,6 +135,9 @@ CREATE TABLE IF NOT EXISTS `matching`
     `created_at`        datetime(6)    NOT NULL,
     `updated_at`        datetime(6)    NOT NULL,
     `is_deleted`   tinyint(1) NOT NULL DEFAULT false,
+    `last_batch_at`     datetime(6) NULL,
+    `expired_at`        datetime(6) NULL,
+    `status`            varchar(20) NULL
 );
 
 CREATE TABLE IF NOT EXISTS `matching_room`

--- a/src/main/resources/db/mariadb/V1_init.sql
+++ b/src/main/resources/db/mariadb/V1_init.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS `position`
 (
     `position_id`  bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `display_name` varchar(20)  NOT NULL,
+    `type`         varchar(20)  NOT NULL,
     `image_url`   varchar(2048)     NOT NULL,
     `created_at`   datetime(6)      NOT NULL,
     `updated_at`   datetime(6)      NOT NULL,
@@ -148,8 +149,8 @@ CREATE TABLE IF NOT EXISTS `matching_room`
     `created_at`   datetime(6) NOT NULL,
     `updated_at`   datetime(6) NOT NULL,
     `is_deleted`   tinyint(1) NOT NULL DEFAULT false,
-    `is_matched`   tinyint(1) NOT NULL DEFAULT false,
-    `matched_at`   datetime(6) NULL
+    `is_complete`   tinyint(1) NOT NULL DEFAULT false,
+    `completed_at`   datetime(6) NULL
 );
 
 CREATE TABLE IF NOT EXISTS `project`

--- a/src/main/resources/db/mariadb/V1_init.sql
+++ b/src/main/resources/db/mariadb/V1_init.sql
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS `matching_room`
     `created_at`   datetime(6) NOT NULL,
     `updated_at`   datetime(6) NOT NULL,
     `is_deleted`   tinyint(1) NOT NULL DEFAULT false,
-    `is_complete`   tinyint(1) NOT NULL DEFAULT false,
+    `is_completed`   tinyint(1) NOT NULL DEFAULT false,
     `completed_at`   datetime(6) NULL
 );
 

--- a/src/main/resources/db/mariadb/V1_init.sql
+++ b/src/main/resources/db/mariadb/V1_init.sql
@@ -126,23 +126,22 @@ CREATE TABLE IF NOT EXISTS `message`
     `is_deleted`   tinyint(1) NOT NULL DEFAULT false
 );
 
-CREATE TABLE IF NOT EXISTS `user_match`
+CREATE TABLE IF NOT EXISTS `matching`
 (
-    `user_match_id`     bigint      NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `matching_id`     bigint      NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `user_id`           bigint      NOT NULL,
     `room_id`           bigint NULL,
     `position_id`       bigint      NOT NULL,
-    `position_skill_id` bigint      NOT NULL,
-    `is_host`           tinyint(1) NOT NULL DEFAULT false,
     `created_at`        datetime(6)    NOT NULL,
     `updated_at`        datetime(6)    NOT NULL,
-    `position`          varchar(10) NOT NULL
+    `is_deleted`   tinyint(1) NOT NULL DEFAULT false,
 );
 
-CREATE TABLE IF NOT EXISTS `room`
+CREATE TABLE IF NOT EXISTS `matching_room`
 (
-    `room_id`      bigint   NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `matching_room_id`      bigint   NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `chat_room_id` bigint   NOT NULL,
+    `host_user_id` bigint   NOT NULL,
     `created_at`   datetime(6) NOT NULL,
     `updated_at`   datetime(6) NOT NULL,
     `is_deleted`   tinyint(1) NOT NULL DEFAULT false,

--- a/src/main/resources/db/mariadb/V1_init.sql
+++ b/src/main/resources/db/mariadb/V1_init.sql
@@ -111,7 +111,6 @@ CREATE TABLE IF NOT EXISTS `chat_room`
     `chat_room_id`   bigint      NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `created_at`     datetime(6)    NOT NULL,
     `updated_at`     datetime(6)    NOT NULL,
-    `chat_room_type` varchar(20) NOT NULL,
     `is_deleted`     tinyint(1) NOT NULL DEFAULT false
 );
 

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 import org.crops.fitserver.domain.matching.dto.MatchingDto;
-import org.crops.fitserver.domain.matching.dto.MatchingMemberView;
+import org.crops.fitserver.domain.matching.dto.MatchingUserView;
 import org.crops.fitserver.domain.matching.dto.request.ForceOutRequest;
 import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
@@ -214,9 +214,9 @@ class MatchingControllerTest extends MockMvcDocs {
       given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
           new GetMatchingRoomResponse(
               roomId, 1L, false, null, principal.getUserId(), List.of(
-              new MatchingMemberView(principal.getUserId(), 1L, user.getUsername(),
+              new MatchingUserView(principal.getUserId(), 1L, user.getUsername(),
                   user.getProfileImageUrl(), true, true),
-              new MatchingMemberView(0L, 1L, user.getUsername(), user.getProfileImageUrl(), true,
+              new MatchingUserView(0L, 1L, user.getUsername(), user.getProfileImageUrl(), true,
                   false)
           )));
       //when
@@ -468,7 +468,7 @@ class MatchingControllerTest extends MockMvcDocs {
       var roomId = 1L;
       var url = "/v1/matching/room/{roomId}/ready";
       willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-          matchingService).readyMatching(principal.getUserId(), roomId);
+          matchingService).ready(principal.getUserId(), roomId);
       //when
       var result = mockMvc.perform(post(url, roomId)
           .contentType(MediaType.APPLICATION_JSON)
@@ -529,7 +529,7 @@ class MatchingControllerTest extends MockMvcDocs {
       var roomId = 1L;
       var url = "/v1/matching/room/{roomId}/complete";
       willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-          matchingService).completeMatching(principal.getUserId(), roomId);
+          matchingService).complete(principal.getUserId(), roomId);
       //when
       var result = mockMvc.perform(post(url, roomId)
           .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -1,0 +1,465 @@
+package org.crops.fitserver.domain.matching.controller;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.fields;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.crops.fitserver.domain.user.util.PrincipalDetailsUtil.getPrincipalDetails;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.EnumFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.crops.fitserver.domain.matching.constant.MatchingStatus;
+import org.crops.fitserver.domain.matching.dto.MatchingDto;
+import org.crops.fitserver.domain.matching.dto.request.ForceOutRequest;
+import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
+import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
+import org.crops.fitserver.domain.matching.service.MatchingService;
+import org.crops.fitserver.global.exception.BusinessException;
+import org.crops.fitserver.global.exception.ErrorCode;
+import org.crops.fitserver.util.MockMvcDocs;
+import org.crops.fitserver.util.UserBuildUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(MatchingController.class)
+@Slf4j
+class MatchingControllerTest extends MockMvcDocs {
+
+  @MockBean
+  private MatchingService matchingService;
+
+  @Override
+  @BeforeEach
+  protected void setUp(RestDocumentationContextProvider restDocumentation) {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .apply(
+            documentationConfiguration(restDocumentation)
+                .operationPreprocessors()
+                .withResponseDefaults(Preprocessors.prettyPrint())
+        )
+        .alwaysDo(print())
+        .build();
+  }
+
+//  @Test
+//  void createMatching_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var url = "/v1/matching/";
+//    given(matchingService.createMatching(principal.getUserId())).willReturn(
+//        new CreateMatchingResponse(
+//            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+//                MatchingStatus.WAITING)));
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/createMatching",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 생성")
+//                    .summary("매칭 생성")
+//                    .responseSchema(Schema.schema("createMatchingResponse"))
+//                    .responseFields(
+//                        fields(
+//                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
+//                                .description("매칭 ID"),
+//                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+//                                .description("방 ID").optional(),
+//                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+//                                .description("포지션 ID"),
+//                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+//                                .description("생성일"),
+//                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+//                                .description("만료일"),
+//                            new EnumFields(MatchingStatus.class).withPath("matching.status")
+//                                .description("매칭 상태")
+//                        )
+//                    )
+//                    .build()
+//            )
+//        ));
+//
+//  }
+//
+//  @Test
+//  void getMatching_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var url = "/v1/matching/";
+//    given(matchingService.getMatching(principal.getUserId())).willReturn(
+//        new GetMatchingResponse(
+//            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+//                MatchingStatus.WAITING)));
+//    //when
+//    var result = mockMvc.perform(get(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/getMatching",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 조회")
+//                    .summary("매칭 조회")
+//                    .responseSchema(Schema.schema("getMatchingResponse"))
+//                    .responseFields(
+//                        fields(
+//                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
+//                                .description("매칭 ID"),
+//                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+//                                .description("방 ID").optional(),
+//                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+//                                .description("포지션 ID"),
+//                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+//                                .description("생성일"),
+//                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+//                                .description("만료일"),
+//                            new EnumFields(MatchingStatus.class).withPath("matching.status")
+//                                .description("매칭 상태")
+//                        )
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void getMatching_fail_매칭중이_아님() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var url = "/v1/matching/";
+//    given(matchingService.getMatching(principal.getUserId())).willThrow(new BusinessException(
+//        ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+//    //when
+//    var result = mockMvc.perform(get(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isNotFound())
+//        .andDo(document("matching/getMatching_fail",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 조회 실패")
+//                    .summary("매칭 조회 실패")
+//                    .responseSchema(Schema.schema("getMatchingResponse"))
+//                    .responseFields(
+//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+//                        fieldWithPath("message").type(JsonFieldType.STRING)
+//                            .description("에러 메시지")
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void getMatchingRoom_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var url = "/v1/matching/room/" + roomId;
+//    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
+//        new GetMatchingRoomResponse(
+//            roomId, 1L, false, null, principal.getUserId()));
+//    //when
+//    var result = mockMvc.perform(get(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/getMatchingRoom",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭방 조회")
+//                    .summary("매칭방 조회")
+//                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
+//                    .responseFields(
+//                        fields(
+//                            fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER).description("방 ID"),
+//                            fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
+//                                .description("채팅방 ID"),
+//                            fieldWithPath("isComplete").type(JsonFieldType.BOOLEAN)
+//                                .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
+//                            fieldWithPath("completedAt").type(JsonFieldType.NULL)
+//                                .description("매칭 완료 일시. null: 매칭 중"),
+//                            fieldWithPath("hostUserId").type(JsonFieldType.NUMBER)
+//                                .description("임시 방장 ID")
+//                        )
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void getMatchingRoom_fail_매칭방이_없음() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var url = "/v1/matching/room/" + roomId;
+//    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willThrow(
+//        new BusinessException(
+//            ErrorCode.Not_EXIST_MATCHING_ROOM_EXCEPTION));
+//    //when
+//    var result = mockMvc.perform(get(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isNotFound())
+//        .andDo(document("matching/getMatchingRoom_fail",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭방 조회 실패")
+//                    .summary("매칭방 조회 실패")
+//                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
+//                    .responseFields(
+//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+//                        fieldWithPath("message").type(JsonFieldType.STRING)
+//                            .description("에러 메시지")
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void forceOut_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var url = "/v1/matching/room/" + roomId + "/force-out";
+//    var forceOutRequest = new ForceOutRequest(2L);
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .content(objectMapper.writeValueAsString(forceOutRequest))
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/forceOut",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("강제퇴장")
+//                    .summary("강제퇴장")
+//                    .requestSchema(Schema.schema("forceOutRequest"))
+//                    .requestFields(
+//                        fieldWithPath("userId").type(JsonFieldType.NUMBER)
+//                            .description("강제퇴장 대상자 ID")
+//                    )
+//                    .build()
+//            )
+//        ));
+//
+//  }
+//
+//  @Test
+//  void forceOut_fail_방장이_아님() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var forceOutUserId = 2L;
+//    var url = "/v1/matching/room/" + roomId + "/force-out";
+//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+//        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+//
+//    var forceOutRequest = new ForceOutRequest(forceOutUserId);
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .content(objectMapper.writeValueAsString(forceOutRequest))
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//
+//    //then
+//    result.andExpect(status().isForbidden())
+//        .andDo(document("matching/forceOut_fail",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("강제퇴장 실패 - 방장이 아님")
+//                    .summary("강제퇴장 실패 - 방장이 아님")
+//                    .responseFields(
+//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+//                        fieldWithPath("message").type(JsonFieldType.STRING)
+//                            .description("에러 메시지")
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void forceOut_fail_대상자가_존재하지_않음() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var forceOutUserId = 2L;
+//    var url = "/v1/matching/room/" + roomId + "/force-out";
+//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+//        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+//
+//    var forceOutRequest = new ForceOutRequest(forceOutUserId);
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .content(objectMapper.writeValueAsString(forceOutRequest))
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//
+//    //then
+//    result.andExpect(status().isForbidden())
+//        .andDo(document("matching/forceOut_fail",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("강제퇴장 실패 - 대상자가 존재하지 않음")
+//                    .summary("강제퇴장 실패 - 대상자가 존재하지 않음")
+//                    .responseSchema(Schema.schema("forceOutRequest"))
+//                    .responseFields(
+//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+//                        fieldWithPath("message").type(JsonFieldType.STRING)
+//                            .description("에러 메시지")
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void completeMatching_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var url = "/v1/matching/room/" + roomId + "/complete";
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/completeMatching",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 완료")
+//                    .summary("매칭 완료")
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void completeMatching_fail_방장이_아님() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var roomId = 1L;
+//    var url = "/v1/matching/room/" + roomId + "/complete";
+//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+//        matchingService).completeMatching(principal.getUserId(), roomId);
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isForbidden())
+//        .andDo(document("matching/completeMatching_fail",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 완료 실패 - 방장이 아님")
+//                    .summary("매칭 완료 실패 - 방장이 아님")
+//                    .responseFields(
+//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+//                        fieldWithPath("message").type(JsonFieldType.STRING)
+//                            .description("에러 메시지")
+//                    )
+//                    .build()
+//            )
+//        ));
+//  }
+//
+//  @Test
+//  void cancelMatching_success() throws Exception {
+//    //given
+//    var user = UserBuildUtil.buildUser().build();
+//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+//    var url = "/v1/matching/cancel";
+//    //when
+//    var result = mockMvc.perform(post(url)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .with(user(principal))
+//        .with(csrf())
+//    );
+//    //then
+//    result.andExpect(status().isOk())
+//        .andDo(document("matching/cancelMatching",
+//            resource(
+//                ResourceSnippetParameters.builder()
+//                    .tag("matching")
+//                    .description("매칭 취소")
+//                    .summary("매칭 취소")
+//                    .build()
+//            )
+//        ));
+//
+//  }
+}

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -219,7 +219,7 @@ class MatchingControllerTest extends MockMvcDocs {
                             fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER).description("방 ID"),
                             fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
                                 .description("채팅방 ID"),
-                            fieldWithPath("isComplete").type(JsonFieldType.BOOLEAN)
+                            fieldWithPath("isCompleted").type(JsonFieldType.BOOLEAN)
                                 .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
                             fieldWithPath("completedAt").type(JsonFieldType.STRING)
                                 .description("매칭 완료 일시. null: 매칭 중").optional(),

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -26,8 +26,6 @@ import org.crops.fitserver.domain.matching.constant.MatchingStatus;
 import org.crops.fitserver.domain.matching.dto.MatchingDto;
 import org.crops.fitserver.domain.matching.dto.MatchingUserView;
 import org.crops.fitserver.domain.matching.dto.request.ForceOutRequest;
-import org.crops.fitserver.domain.matching.dto.response.CreateMatchingResponse;
-import org.crops.fitserver.domain.matching.dto.response.GetMatchingResponse;
 import org.crops.fitserver.domain.matching.dto.response.GetMatchingRoomResponse;
 import org.crops.fitserver.domain.matching.service.MatchingService;
 import org.crops.fitserver.global.exception.BusinessException;
@@ -80,9 +78,8 @@ class MatchingControllerTest extends MockMvcDocs {
       var user = UserBuildUtil.buildUser().build();
       var principal = getPrincipalDetails(user.getId(), user.getUserRole());
       given(matchingService.createMatching(principal.getUserId())).willReturn(
-          new CreateMatchingResponse(
-              new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-                  MatchingStatus.WAITING)));
+          new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+              MatchingStatus.WAITING));
       //when
       var result = mockMvc.perform(post(URL)
           .contentType(MediaType.APPLICATION_JSON)
@@ -100,17 +97,17 @@ class MatchingControllerTest extends MockMvcDocs {
                       .responseSchema(Schema.schema("createMatchingResponse"))
                       .responseFields(
                           fields(
-                              fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("userId").type(JsonFieldType.NUMBER)
                                   .description("유저 ID"),
-                              fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("roomId").type(JsonFieldType.NUMBER)
                                   .description("방 ID").optional(),
-                              fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("positionId").type(JsonFieldType.NUMBER)
                                   .description("포지션 ID"),
-                              fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                              fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                   .description("생성일"),
-                              fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                              fieldWithPath("expiredAt").type(JsonFieldType.STRING)
                                   .description("만료일"),
-                              new EnumFields(MatchingStatus.class).withPath("matching.status")
+                              new EnumFields(MatchingStatus.class).withPath("status")
                                   .description("매칭 상태")
                           )
                       )
@@ -126,9 +123,8 @@ class MatchingControllerTest extends MockMvcDocs {
       var user = UserBuildUtil.buildUser().build();
       var principal = getPrincipalDetails(user.getId(), user.getUserRole());
       given(matchingService.getMatching(principal.getUserId())).willReturn(
-          new GetMatchingResponse(
-              new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-                  MatchingStatus.WAITING)));
+          new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+              MatchingStatus.WAITING));
       //when
       var result = mockMvc.perform(get(URL)
           .contentType(MediaType.APPLICATION_JSON)
@@ -146,17 +142,17 @@ class MatchingControllerTest extends MockMvcDocs {
                       .responseSchema(Schema.schema("getMatchingResponse"))
                       .responseFields(
                           fields(
-                              fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("userId").type(JsonFieldType.NUMBER)
                                   .description("유저 ID"),
-                              fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("roomId").type(JsonFieldType.NUMBER)
                                   .description("방 ID").optional(),
-                              fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                              fieldWithPath("positionId").type(JsonFieldType.NUMBER)
                                   .description("포지션 ID"),
-                              fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                              fieldWithPath("createdAt").type(JsonFieldType.STRING)
                                   .description("생성일"),
-                              fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                              fieldWithPath("expiredAt").type(JsonFieldType.STRING)
                                   .description("만료일"),
-                              new EnumFields(MatchingStatus.class).withPath("matching.status")
+                              new EnumFields(MatchingStatus.class).withPath("status")
                                   .description("매칭 상태")
                           )
                       )

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -63,403 +63,403 @@ class MatchingControllerTest extends MockMvcDocs {
         .build();
   }
 
-//  @Test
-//  void createMatching_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var url = "/v1/matching/";
-//    given(matchingService.createMatching(principal.getUserId())).willReturn(
-//        new CreateMatchingResponse(
-//            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-//                MatchingStatus.WAITING)));
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/createMatching",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 생성")
-//                    .summary("매칭 생성")
-//                    .responseSchema(Schema.schema("createMatchingResponse"))
-//                    .responseFields(
-//                        fields(
-//                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
-//                                .description("매칭 ID"),
-//                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
-//                                .description("방 ID").optional(),
-//                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
-//                                .description("포지션 ID"),
-//                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
-//                                .description("생성일"),
-//                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
-//                                .description("만료일"),
-//                            new EnumFields(MatchingStatus.class).withPath("matching.status")
-//                                .description("매칭 상태")
-//                        )
-//                    )
-//                    .build()
-//            )
-//        ));
-//
-//  }
-//
-//  @Test
-//  void getMatching_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var url = "/v1/matching/";
-//    given(matchingService.getMatching(principal.getUserId())).willReturn(
-//        new GetMatchingResponse(
-//            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-//                MatchingStatus.WAITING)));
-//    //when
-//    var result = mockMvc.perform(get(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/getMatching",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 조회")
-//                    .summary("매칭 조회")
-//                    .responseSchema(Schema.schema("getMatchingResponse"))
-//                    .responseFields(
-//                        fields(
-//                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
-//                                .description("매칭 ID"),
-//                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
-//                                .description("방 ID").optional(),
-//                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
-//                                .description("포지션 ID"),
-//                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
-//                                .description("생성일"),
-//                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
-//                                .description("만료일"),
-//                            new EnumFields(MatchingStatus.class).withPath("matching.status")
-//                                .description("매칭 상태")
-//                        )
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void getMatching_fail_매칭중이_아님() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var url = "/v1/matching/";
-//    given(matchingService.getMatching(principal.getUserId())).willThrow(new BusinessException(
-//        ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
-//    //when
-//    var result = mockMvc.perform(get(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isNotFound())
-//        .andDo(document("matching/getMatching_fail",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 조회 실패")
-//                    .summary("매칭 조회 실패")
-//                    .responseSchema(Schema.schema("getMatchingResponse"))
-//                    .responseFields(
-//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-//                        fieldWithPath("message").type(JsonFieldType.STRING)
-//                            .description("에러 메시지")
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void getMatchingRoom_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var url = "/v1/matching/room/" + roomId;
-//    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
-//        new GetMatchingRoomResponse(
-//            roomId, 1L, false, null, principal.getUserId()));
-//    //when
-//    var result = mockMvc.perform(get(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/getMatchingRoom",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭방 조회")
-//                    .summary("매칭방 조회")
-//                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
-//                    .responseFields(
-//                        fields(
-//                            fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER).description("방 ID"),
-//                            fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
-//                                .description("채팅방 ID"),
-//                            fieldWithPath("isComplete").type(JsonFieldType.BOOLEAN)
-//                                .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
-//                            fieldWithPath("completedAt").type(JsonFieldType.NULL)
-//                                .description("매칭 완료 일시. null: 매칭 중"),
-//                            fieldWithPath("hostUserId").type(JsonFieldType.NUMBER)
-//                                .description("임시 방장 ID")
-//                        )
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void getMatchingRoom_fail_매칭방이_없음() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var url = "/v1/matching/room/" + roomId;
-//    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willThrow(
-//        new BusinessException(
-//            ErrorCode.Not_EXIST_MATCHING_ROOM_EXCEPTION));
-//    //when
-//    var result = mockMvc.perform(get(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isNotFound())
-//        .andDo(document("matching/getMatchingRoom_fail",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭방 조회 실패")
-//                    .summary("매칭방 조회 실패")
-//                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
-//                    .responseFields(
-//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-//                        fieldWithPath("message").type(JsonFieldType.STRING)
-//                            .description("에러 메시지")
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void forceOut_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var url = "/v1/matching/room/" + roomId + "/force-out";
-//    var forceOutRequest = new ForceOutRequest(2L);
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .content(objectMapper.writeValueAsString(forceOutRequest))
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/forceOut",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("강제퇴장")
-//                    .summary("강제퇴장")
-//                    .requestSchema(Schema.schema("forceOutRequest"))
-//                    .requestFields(
-//                        fieldWithPath("userId").type(JsonFieldType.NUMBER)
-//                            .description("강제퇴장 대상자 ID")
-//                    )
-//                    .build()
-//            )
-//        ));
-//
-//  }
-//
-//  @Test
-//  void forceOut_fail_방장이_아님() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var forceOutUserId = 2L;
-//    var url = "/v1/matching/room/" + roomId + "/force-out";
-//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-//        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
-//
-//    var forceOutRequest = new ForceOutRequest(forceOutUserId);
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .content(objectMapper.writeValueAsString(forceOutRequest))
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//
-//    //then
-//    result.andExpect(status().isForbidden())
-//        .andDo(document("matching/forceOut_fail",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("강제퇴장 실패 - 방장이 아님")
-//                    .summary("강제퇴장 실패 - 방장이 아님")
-//                    .responseFields(
-//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-//                        fieldWithPath("message").type(JsonFieldType.STRING)
-//                            .description("에러 메시지")
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void forceOut_fail_대상자가_존재하지_않음() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var forceOutUserId = 2L;
-//    var url = "/v1/matching/room/" + roomId + "/force-out";
-//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-//        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
-//
-//    var forceOutRequest = new ForceOutRequest(forceOutUserId);
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .content(objectMapper.writeValueAsString(forceOutRequest))
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//
-//    //then
-//    result.andExpect(status().isForbidden())
-//        .andDo(document("matching/forceOut_fail",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("강제퇴장 실패 - 대상자가 존재하지 않음")
-//                    .summary("강제퇴장 실패 - 대상자가 존재하지 않음")
-//                    .responseSchema(Schema.schema("forceOutRequest"))
-//                    .responseFields(
-//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-//                        fieldWithPath("message").type(JsonFieldType.STRING)
-//                            .description("에러 메시지")
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void completeMatching_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var url = "/v1/matching/room/" + roomId + "/complete";
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/completeMatching",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 완료")
-//                    .summary("매칭 완료")
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void completeMatching_fail_방장이_아님() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var roomId = 1L;
-//    var url = "/v1/matching/room/" + roomId + "/complete";
-//    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-//        matchingService).completeMatching(principal.getUserId(), roomId);
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isForbidden())
-//        .andDo(document("matching/completeMatching_fail",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 완료 실패 - 방장이 아님")
-//                    .summary("매칭 완료 실패 - 방장이 아님")
-//                    .responseFields(
-//                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-//                        fieldWithPath("message").type(JsonFieldType.STRING)
-//                            .description("에러 메시지")
-//                    )
-//                    .build()
-//            )
-//        ));
-//  }
-//
-//  @Test
-//  void cancelMatching_success() throws Exception {
-//    //given
-//    var user = UserBuildUtil.buildUser().build();
-//    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-//    var url = "/v1/matching/cancel";
-//    //when
-//    var result = mockMvc.perform(post(url)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .with(user(principal))
-//        .with(csrf())
-//    );
-//    //then
-//    result.andExpect(status().isOk())
-//        .andDo(document("matching/cancelMatching",
-//            resource(
-//                ResourceSnippetParameters.builder()
-//                    .tag("matching")
-//                    .description("매칭 취소")
-//                    .summary("매칭 취소")
-//                    .build()
-//            )
-//        ));
-//
-//  }
+  @Test
+  void createMatching_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var url = "/v1/matching/";
+    given(matchingService.createMatching(principal.getUserId())).willReturn(
+        new CreateMatchingResponse(
+            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+                MatchingStatus.WAITING)));
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/createMatching",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 생성")
+                    .summary("매칭 생성")
+                    .responseSchema(Schema.schema("createMatchingResponse"))
+                    .responseFields(
+                        fields(
+                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
+                                .description("매칭 ID"),
+                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                                .description("방 ID").optional(),
+                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                                .description("포지션 ID"),
+                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                                .description("생성일"),
+                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                                .description("만료일"),
+                            new EnumFields(MatchingStatus.class).withPath("matching.status")
+                                .description("매칭 상태")
+                        )
+                    )
+                    .build()
+            )
+        ));
+
+  }
+
+  @Test
+  void getMatching_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var url = "/v1/matching/";
+    given(matchingService.getMatching(principal.getUserId())).willReturn(
+        new GetMatchingResponse(
+            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+                MatchingStatus.WAITING)));
+    //when
+    var result = mockMvc.perform(get(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/getMatching",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 조회")
+                    .summary("매칭 조회")
+                    .responseSchema(Schema.schema("getMatchingResponse"))
+                    .responseFields(
+                        fields(
+                            fieldWithPath("matching.matchingId").type(JsonFieldType.NUMBER)
+                                .description("매칭 ID"),
+                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                                .description("방 ID").optional(),
+                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                                .description("포지션 ID"),
+                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                                .description("생성일"),
+                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                                .description("만료일"),
+                            new EnumFields(MatchingStatus.class).withPath("matching.status")
+                                .description("매칭 상태")
+                        )
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void getMatching_fail_매칭중이_아님() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var url = "/v1/matching/";
+    given(matchingService.getMatching(principal.getUserId())).willThrow(new BusinessException(
+        ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+    //when
+    var result = mockMvc.perform(get(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isNotFound())
+        .andDo(document("matching/getMatching_fail",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 조회 실패")
+                    .summary("매칭 조회 실패")
+                    .responseSchema(Schema.schema("errorResponse"))
+                    .responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("에러 메시지")
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void getMatchingRoom_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var url = "/v1/matching/room/" + roomId;
+    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
+        new GetMatchingRoomResponse(
+            roomId, 1L, false, null, principal.getUserId()));
+    //when
+    var result = mockMvc.perform(get(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/getMatchingRoom",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭방 조회")
+                    .summary("매칭방 조회")
+                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
+                    .responseFields(
+                        fields(
+                            fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER).description("방 ID"),
+                            fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
+                                .description("채팅방 ID"),
+                            fieldWithPath("isComplete").type(JsonFieldType.BOOLEAN)
+                                .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
+                            fieldWithPath("completedAt").type(JsonFieldType.STRING)
+                                .description("매칭 완료 일시. null: 매칭 중").optional(),
+                            fieldWithPath("hostUserId").type(JsonFieldType.NUMBER)
+                                .description("임시 방장 ID")
+                        )
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void getMatchingRoom_fail_매칭방이_없음() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var url = "/v1/matching/room/" + roomId;
+    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willThrow(
+        new BusinessException(
+            ErrorCode.Not_EXIST_MATCHING_ROOM_EXCEPTION));
+    //when
+    var result = mockMvc.perform(get(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isNotFound())
+        .andDo(document("matching/getMatchingRoom_fail",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭방 조회 실패")
+                    .summary("매칭방 조회 실패")
+                    .responseSchema(Schema.schema("errorResponse"))
+                    .responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("에러 메시지")
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void forceOut_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var url = "/v1/matching/room/" + roomId + "/force-out";
+    var forceOutRequest = new ForceOutRequest(2L);
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(forceOutRequest))
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/forceOut",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("강제퇴장")
+                    .summary("강제퇴장")
+                    .requestSchema(Schema.schema("forceOutRequest"))
+                    .requestFields(
+                        fieldWithPath("userId").type(JsonFieldType.NUMBER)
+                            .description("강제퇴장 대상자 ID")
+                    )
+                    .build()
+            )
+        ));
+
+  }
+
+  @Test
+  void forceOut_fail_방장이_아님() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var forceOutUserId = 2L;
+    var url = "/v1/matching/room/" + roomId + "/force-out";
+    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+
+    var forceOutRequest = new ForceOutRequest(forceOutUserId);
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(forceOutRequest))
+        .with(user(principal))
+        .with(csrf())
+    );
+
+    //then
+    result.andExpect(status().isForbidden())
+        .andDo(document("matching/forceOut_fail",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("강제퇴장 실패 - 방장이 아님")
+                    .summary("강제퇴장 실패 - 방장이 아님")
+                    .responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("에러 메시지")
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void forceOut_fail_대상자가_존재하지_않음() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var forceOutUserId = 2L;
+    var url = "/v1/matching/room/" + roomId + "/force-out";
+    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+
+    var forceOutRequest = new ForceOutRequest(forceOutUserId);
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(forceOutRequest))
+        .with(user(principal))
+        .with(csrf())
+    );
+
+    //then
+    result.andExpect(status().isForbidden())
+        .andDo(document("matching/forceOut_fail",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("강제퇴장 실패 - 대상자가 존재하지 않음")
+                    .summary("강제퇴장 실패 - 대상자가 존재하지 않음")
+                    .responseSchema(Schema.schema("forceOutRequest"))
+                    .responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("에러 메시지")
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void completeMatching_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var url = "/v1/matching/room/" + roomId + "/complete";
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/completeMatching",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 완료")
+                    .summary("매칭 완료")
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void completeMatching_fail_방장이_아님() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var roomId = 1L;
+    var url = "/v1/matching/room/" + roomId + "/complete";
+    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+        matchingService).completeMatching(principal.getUserId(), roomId);
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isForbidden())
+        .andDo(document("matching/completeMatching_fail",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 완료 실패 - 방장이 아님")
+                    .summary("매칭 완료 실패 - 방장이 아님")
+                    .responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING)
+                            .description("에러 메시지")
+                    )
+                    .build()
+            )
+        ));
+  }
+
+  @Test
+  void cancelMatching_success() throws Exception {
+    //given
+    var user = UserBuildUtil.buildUser().build();
+    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+    var url = "/v1/matching/cancel";
+    //when
+    var result = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(user(principal))
+        .with(csrf())
+    );
+    //then
+    result.andExpect(status().isOk())
+        .andDo(document("matching/cancelMatching",
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("matching")
+                    .description("매칭 취소")
+                    .summary("매칭 취소")
+                    .build()
+            )
+        ));
+
+  }
 }

--- a/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/matching/controller/MatchingControllerTest.java
@@ -35,6 +35,8 @@ import org.crops.fitserver.global.exception.ErrorCode;
 import org.crops.fitserver.util.MockMvcDocs;
 import org.crops.fitserver.util.UserBuildUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -65,484 +67,523 @@ class MatchingControllerTest extends MockMvcDocs {
         .build();
   }
 
-  @Test
-  void createMatching_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var url = "/v1/matching";
-    given(matchingService.createMatching(principal.getUserId())).willReturn(
-        new CreateMatchingResponse(
-            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-                MatchingStatus.WAITING)));
-    //when
-    var result = mockMvc.perform(post(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/createMatching",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 생성")
-                    .summary("매칭 생성")
-                    .responseSchema(Schema.schema("createMatchingResponse"))
-                    .responseFields(
-                        fields(
-                            fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
-                                .description("유저 ID"),
-                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
-                                .description("방 ID").optional(),
-                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
-                                .description("포지션 ID"),
-                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
-                                .description("생성일"),
-                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
-                                .description("만료일"),
-                            new EnumFields(MatchingStatus.class).withPath("matching.status")
-                                .description("매칭 상태")
-                        )
-                    )
-                    .build()
-            )
-        ));
+  @Nested
+  @DisplayName("매칭 생성/조회 테스트")
+  class MatchingTest {
+
+    private static final String URL = "/v1/matching";
+
+    @DisplayName("매칭 생성 성공")
+    @Test
+    void createMatching_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      given(matchingService.createMatching(principal.getUserId())).willReturn(
+          new CreateMatchingResponse(
+              new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+                  MatchingStatus.WAITING)));
+      //when
+      var result = mockMvc.perform(post(URL)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/createMatching",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 생성")
+                      .summary("매칭 생성")
+                      .responseSchema(Schema.schema("createMatchingResponse"))
+                      .responseFields(
+                          fields(
+                              fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
+                                  .description("유저 ID"),
+                              fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                                  .description("방 ID").optional(),
+                              fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                                  .description("포지션 ID"),
+                              fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                                  .description("생성일"),
+                              fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                                  .description("만료일"),
+                              new EnumFields(MatchingStatus.class).withPath("matching.status")
+                                  .description("매칭 상태")
+                          )
+                      )
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 조회 성공")
+    void getMatching_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      given(matchingService.getMatching(principal.getUserId())).willReturn(
+          new GetMatchingResponse(
+              new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
+                  MatchingStatus.WAITING)));
+      //when
+      var result = mockMvc.perform(get(URL)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/getMatching",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 조회")
+                      .summary("매칭 조회")
+                      .responseSchema(Schema.schema("getMatchingResponse"))
+                      .responseFields(
+                          fields(
+                              fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
+                                  .description("유저 ID"),
+                              fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
+                                  .description("방 ID").optional(),
+                              fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
+                                  .description("포지션 ID"),
+                              fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
+                                  .description("생성일"),
+                              fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
+                                  .description("만료일"),
+                              new EnumFields(MatchingStatus.class).withPath("matching.status")
+                                  .description("매칭 상태")
+                          )
+                      )
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 조회 실패 - 매칭중이 아님")
+    void getMatching_fail_매칭중이_아님() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      given(matchingService.getMatching(principal.getUserId())).willThrow(new BusinessException(
+          ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
+      //when
+      var result = mockMvc.perform(get(URL)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isNotFound())
+          .andDo(document("matching/getMatching_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 조회 실패")
+                      .summary("매칭 조회 실패")
+                      .responseSchema(Schema.schema("errorResponse"))
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
+  }
+
+  @Nested
+  @DisplayName("매칭방 테스트")
+  class MatchingRoomTest {
+
+    @Test
+    @DisplayName("매칭방 조회 성공")
+    void getMatchingRoom_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}";
+      given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
+          new GetMatchingRoomResponse(
+              roomId, 1L, false, null, principal.getUserId(), List.of(
+              new MatchingMemberView(principal.getUserId(), 1L, user.getUsername(),
+                  user.getProfileImageUrl(), true, true),
+              new MatchingMemberView(0L, 1L, user.getUsername(), user.getProfileImageUrl(), true,
+                  false)
+          )));
+      //when
+      var result = mockMvc.perform(get(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/getMatchingRoom",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭방 조회")
+                      .summary("매칭방 조회")
+                      .responseSchema(Schema.schema("getMatchingRoomResponse"))
+                      .responseFields(
+                          fields(
+                              fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER)
+                                  .description("방 ID"),
+                              fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
+                                  .description("채팅방 ID"),
+                              fieldWithPath("isCompleted").type(JsonFieldType.BOOLEAN)
+                                  .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
+                              fieldWithPath("completedAt").type(JsonFieldType.STRING)
+                                  .description("매칭 완료 일시. null: 매칭 중").optional(),
+                              fieldWithPath("hostUserId").type(JsonFieldType.NUMBER)
+                                  .description("임시 방장 ID"),
+                              fieldWithPath("matchingUserList").type(JsonFieldType.ARRAY)
+                                  .description("매칭 멤버 목록").optional(),
+                              fieldWithPath("matchingUserList[].userId").type(JsonFieldType.NUMBER)
+                                  .description("유저 ID"),
+                              fieldWithPath("matchingUserList[].positionId").type(
+                                      JsonFieldType.NUMBER)
+                                  .description("포지션 ID"),
+                              fieldWithPath("matchingUserList[].username").type(
+                                      JsonFieldType.STRING)
+                                  .description("유저 이름"),
+                              fieldWithPath("matchingUserList[].profileImageUrl").type(
+                                      JsonFieldType.STRING)
+                                  .description("프로필 이미지 URL"),
+                              fieldWithPath("matchingUserList[].isHost").type(JsonFieldType.BOOLEAN)
+                                  .description("방장 여부"),
+                              fieldWithPath("matchingUserList[].isReady").type(
+                                      JsonFieldType.BOOLEAN)
+                                  .description("준비 여부")
+                          )
+                      )
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭방 조회 실패 - 매칭방이 없음")
+    void getMatchingRoom_fail_매칭방이_없음() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}";
+      given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willThrow(
+          new BusinessException(
+              ErrorCode.NOT_EXIST_MATCHING_ROOM_EXCEPTION));
+      //when
+      var result = mockMvc.perform(get(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isNotFound())
+          .andDo(document("matching/getMatchingRoom_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭방 조회 실패")
+                      .summary("매칭방 조회 실패")
+                      .responseSchema(Schema.schema("errorResponse"))
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
 
   }
 
-  @Test
-  void getMatching_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var url = "/v1/matching";
-    given(matchingService.getMatching(principal.getUserId())).willReturn(
-        new GetMatchingResponse(
-            new MatchingDto(1L, 1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(3),
-                MatchingStatus.WAITING)));
-    //when
-    var result = mockMvc.perform(get(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/getMatching",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 조회")
-                    .summary("매칭 조회")
-                    .responseSchema(Schema.schema("getMatchingResponse"))
-                    .responseFields(
-                        fields(
-                            fieldWithPath("matching.userId").type(JsonFieldType.NUMBER)
-                                .description("유저 ID"),
-                            fieldWithPath("matching.roomId").type(JsonFieldType.NUMBER)
-                                .description("방 ID").optional(),
-                            fieldWithPath("matching.positionId").type(JsonFieldType.NUMBER)
-                                .description("포지션 ID"),
-                            fieldWithPath("matching.createdAt").type(JsonFieldType.STRING)
-                                .description("생성일"),
-                            fieldWithPath("matching.expiredAt").type(JsonFieldType.STRING)
-                                .description("만료일"),
-                            new EnumFields(MatchingStatus.class).withPath("matching.status")
-                                .description("매칭 상태")
-                        )
-                    )
-                    .build()
-            )
-        ));
+  @Nested
+  @DisplayName("매칭 강제 퇴장 테스트")
+  class MatchingForceOutTest {
+
+    @Test
+    @DisplayName("매칭 강제 퇴장 성공")
+    void forceOut_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}/force-out";
+      var forceOutRequest = new ForceOutRequest(2L);
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(forceOutRequest))
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/forceOut",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("강제퇴장")
+                      .summary("강제퇴장")
+                      .requestSchema(Schema.schema("forceOutRequest"))
+                      .requestFields(
+                          fieldWithPath("userId").type(JsonFieldType.NUMBER)
+                              .description("강제퇴장 대상자 ID")
+                      )
+                      .build()
+              )
+          ));
+
+    }
+
+    @Test
+    @DisplayName("매칭 강제 퇴장 실패 - 방장이 아님")
+    void forceOut_fail_방장이_아님() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var forceOutUserId = 2L;
+      var url = "/v1/matching/room/{roomId}/force-out";
+      willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+          matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+
+      var forceOutRequest = new ForceOutRequest(forceOutUserId);
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(forceOutRequest))
+          .with(user(principal))
+          .with(csrf())
+      );
+
+      //then
+      result.andExpect(status().isForbidden())
+          .andDo(document("matching/forceOut_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("강제퇴장 실패 - 방장이 아님")
+                      .summary("강제퇴장 실패 - 방장이 아님")
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 강제 퇴장 실패 - 대상자가 존재하지 않음")
+    void forceOut_fail_대상자가_존재하지_않음() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var forceOutUserId = 2L;
+      var url = "/v1/matching/room/{roomId}/force-out";
+      willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+          matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
+
+      var forceOutRequest = new ForceOutRequest(forceOutUserId);
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(forceOutRequest))
+          .with(user(principal))
+          .with(csrf())
+      );
+
+      //then
+      result.andExpect(status().isForbidden())
+          .andDo(document("matching/forceOut_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("강제퇴장 실패 - 대상자가 존재하지 않음")
+                      .summary("강제퇴장 실패 - 대상자가 존재하지 않음")
+                      .responseSchema(Schema.schema("forceOutRequest"))
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
   }
 
-  @Test
-  void getMatching_fail_매칭중이_아님() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var url = "/v1/matching";
-    given(matchingService.getMatching(principal.getUserId())).willThrow(new BusinessException(
-        ErrorCode.NOT_EXIST_MATCHING_EXCEPTION));
-    //when
-    var result = mockMvc.perform(get(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isNotFound())
-        .andDo(document("matching/getMatching_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 조회 실패")
-                    .summary("매칭 조회 실패")
-                    .responseSchema(Schema.schema("errorResponse"))
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
+  @Nested
+  @DisplayName("매칭 준비/완료 테스트")
+  class MatchingReadyAndCompleteTest {
+
+    @Test
+    @DisplayName("매칭 준비 성공")
+    void readyMatching_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}/ready";
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/readyMatching",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 준비")
+                      .summary("매칭 준비")
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 준비 실패 - 방장은 준비할 수 없음")
+    void readyMatching_fail_host_can_not_ready() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}/ready";
+      willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+          matchingService).readyMatching(principal.getUserId(), roomId);
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isForbidden())
+          .andDo(document("matching/readyMatching_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 준비 실패 - 방장은 준비할 수 없음")
+                      .summary("매칭 준비 실패 - 방장은 준비할 수 없음")
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 완료 성공")
+    void completeMatching_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}/complete";
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/completeMatching",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 완료")
+                      .summary("매칭 완료")
+                      .build()
+              )
+          ));
+    }
+
+    @Test
+    @DisplayName("매칭 완료 실패 - 방장이 아님")
+    void completeMatching_fail_방장이_아님() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var roomId = 1L;
+      var url = "/v1/matching/room/{roomId}/complete";
+      willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
+          matchingService).completeMatching(principal.getUserId(), roomId);
+      //when
+      var result = mockMvc.perform(post(url, roomId)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isForbidden())
+          .andDo(document("matching/completeMatching_fail",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 완료 실패 - 방장이 아님")
+                      .summary("매칭 완료 실패 - 방장이 아님")
+                      .responseFields(
+                          fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                          fieldWithPath("message").type(JsonFieldType.STRING)
+                              .description("에러 메시지")
+                      )
+                      .build()
+              )
+          ));
+    }
   }
 
-  @Test
-  void getMatchingRoom_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}";
-    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willReturn(
-        new GetMatchingRoomResponse(
-            roomId, 1L, false, null, principal.getUserId(), List.of(
-            new MatchingMemberView(principal.getUserId(), 1L, user.getUsername(),
-                user.getProfileImageUrl(), true, true),
-            new MatchingMemberView(0L, 1L, user.getUsername(), user.getProfileImageUrl(), true,
-                false)
-        )));
-    //when
-    var result = mockMvc.perform(get(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/getMatchingRoom",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭방 조회")
-                    .summary("매칭방 조회")
-                    .responseSchema(Schema.schema("getMatchingRoomResponse"))
-                    .responseFields(
-                        fields(
-                            fieldWithPath("matchingRoomId").type(JsonFieldType.NUMBER)
-                                .description("방 ID"),
-                            fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER)
-                                .description("채팅방 ID"),
-                            fieldWithPath("isCompleted").type(JsonFieldType.BOOLEAN)
-                                .description("매칭 완료 여부. true: 매칭 모두 완료, false: 매칭 중"),
-                            fieldWithPath("completedAt").type(JsonFieldType.STRING)
-                                .description("매칭 완료 일시. null: 매칭 중").optional(),
-                            fieldWithPath("hostUserId").type(JsonFieldType.NUMBER)
-                                .description("임시 방장 ID"),
-                            fieldWithPath("matchingUserList").type(JsonFieldType.ARRAY)
-                                .description("매칭 멤버 목록").optional(),
-                            fieldWithPath("matchingUserList[].userId").type(JsonFieldType.NUMBER)
-                                .description("유저 ID"),
-                            fieldWithPath("matchingUserList[].positionId").type(
-                                    JsonFieldType.NUMBER)
-                                .description("포지션 ID"),
-                            fieldWithPath("matchingUserList[].username").type(JsonFieldType.STRING)
-                                .description("유저 이름"),
-                            fieldWithPath("matchingUserList[].profileImageUrl").type(
-                                    JsonFieldType.STRING)
-                                .description("프로필 이미지 URL"),
-                            fieldWithPath("matchingUserList[].isHost").type(JsonFieldType.BOOLEAN)
-                                .description("방장 여부"),
-                            fieldWithPath("matchingUserList[].isReady").type(JsonFieldType.BOOLEAN)
-                                .description("준비 여부")
-                        )
-                    )
-                    .build()
-            )
-        ));
-  }
+  @Nested
+  @DisplayName("매칭 취소 테스트")
+  class MatchingCancelTest {
 
-  @Test
-  void getMatchingRoom_fail_매칭방이_없음() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}";
-    given(matchingService.getMatchingRoom(principal.getUserId(), roomId)).willThrow(
-        new BusinessException(
-            ErrorCode.NOT_EXIST_MATCHING_ROOM_EXCEPTION));
-    //when
-    var result = mockMvc.perform(get(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isNotFound())
-        .andDo(document("matching/getMatchingRoom_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭방 조회 실패")
-                    .summary("매칭방 조회 실패")
-                    .responseSchema(Schema.schema("errorResponse"))
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
-  }
+    @Test
+    @DisplayName("매칭 취소 성공")
+    void cancelMatching_success() throws Exception {
+      //given
+      var user = UserBuildUtil.buildUser().build();
+      var principal = getPrincipalDetails(user.getId(), user.getUserRole());
+      var url = "/v1/matching/cancel";
+      //when
+      var result = mockMvc.perform(post(url)
+          .contentType(MediaType.APPLICATION_JSON)
+          .with(user(principal))
+          .with(csrf())
+      );
+      //then
+      result.andExpect(status().isOk())
+          .andDo(document("matching/cancelMatching",
+              resource(
+                  ResourceSnippetParameters.builder()
+                      .tag("matching")
+                      .description("매칭 취소")
+                      .summary("매칭 취소")
+                      .build()
+              )
+          ));
 
-  @Test
-  void forceOut_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}/force-out";
-    var forceOutRequest = new ForceOutRequest(2L);
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(forceOutRequest))
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/forceOut",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("강제퇴장")
-                    .summary("강제퇴장")
-                    .requestSchema(Schema.schema("forceOutRequest"))
-                    .requestFields(
-                        fieldWithPath("userId").type(JsonFieldType.NUMBER)
-                            .description("강제퇴장 대상자 ID")
-                    )
-                    .build()
-            )
-        ));
-
-  }
-
-  @Test
-  void forceOut_fail_방장이_아님() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var forceOutUserId = 2L;
-    var url = "/v1/matching/room/{roomId}/force-out";
-    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
-
-    var forceOutRequest = new ForceOutRequest(forceOutUserId);
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(forceOutRequest))
-        .with(user(principal))
-        .with(csrf())
-    );
-
-    //then
-    result.andExpect(status().isForbidden())
-        .andDo(document("matching/forceOut_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("강제퇴장 실패 - 방장이 아님")
-                    .summary("강제퇴장 실패 - 방장이 아님")
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void forceOut_fail_대상자가_존재하지_않음() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var forceOutUserId = 2L;
-    var url = "/v1/matching/room/{roomId}/force-out";
-    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-        matchingService).forceOut(principal.getUserId(), roomId, forceOutUserId);
-
-    var forceOutRequest = new ForceOutRequest(forceOutUserId);
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(forceOutRequest))
-        .with(user(principal))
-        .with(csrf())
-    );
-
-    //then
-    result.andExpect(status().isForbidden())
-        .andDo(document("matching/forceOut_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("강제퇴장 실패 - 대상자가 존재하지 않음")
-                    .summary("강제퇴장 실패 - 대상자가 존재하지 않음")
-                    .responseSchema(Schema.schema("forceOutRequest"))
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void readyMatching_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}/ready";
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/readyMatching",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 준비")
-                    .summary("매칭 준비")
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void readyMatching_fail_host_can_not_ready() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}/ready";
-    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-        matchingService).readyMatching(principal.getUserId(), roomId);
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isForbidden())
-        .andDo(document("matching/readyMatching_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 준비 실패 - 방장은 준비할 수 없음")
-                    .summary("매칭 준비 실패 - 방장은 준비할 수 없음")
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void completeMatching_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}/complete";
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/completeMatching",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 완료")
-                    .summary("매칭 완료")
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void completeMatching_fail_방장이_아님() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var roomId = 1L;
-    var url = "/v1/matching/room/{roomId}/complete";
-    willThrow(new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION)).willDoNothing().given(
-        matchingService).completeMatching(principal.getUserId(), roomId);
-    //when
-    var result = mockMvc.perform(post(url, roomId)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isForbidden())
-        .andDo(document("matching/completeMatching_fail",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 완료 실패 - 방장이 아님")
-                    .summary("매칭 완료 실패 - 방장이 아님")
-                    .responseFields(
-                        fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                        fieldWithPath("message").type(JsonFieldType.STRING)
-                            .description("에러 메시지")
-                    )
-                    .build()
-            )
-        ));
-  }
-
-  @Test
-  void cancelMatching_success() throws Exception {
-    //given
-    var user = UserBuildUtil.buildUser().build();
-    var principal = getPrincipalDetails(user.getId(), user.getUserRole());
-    var url = "/v1/matching/cancel";
-    //when
-    var result = mockMvc.perform(post(url)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(user(principal))
-        .with(csrf())
-    );
-    //then
-    result.andExpect(status().isOk())
-        .andDo(document("matching/cancelMatching",
-            resource(
-                ResourceSnippetParameters.builder()
-                    .tag("matching")
-                    .description("매칭 취소")
-                    .summary("매칭 취소")
-                    .build()
-            )
-        ));
-
+    }
   }
 }

--- a/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/org/crops/fitserver/domain/user/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.EnumFields;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.crops.fitserver.domain.region.domain.Region;
@@ -38,6 +39,7 @@ import org.crops.fitserver.domain.user.dto.request.UpdatePolicyAgreementRequest;
 import org.crops.fitserver.domain.user.dto.request.UpdateUserRequest;
 import org.crops.fitserver.domain.user.facade.UserFacade;
 import org.crops.fitserver.util.MockMvcDocs;
+import org.crops.fitserver.util.UserBuildUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -73,15 +75,7 @@ class UserControllerTest extends MockMvcDocs {
   @Test
   void getUser_success() throws Exception {
     // given
-    var linkList = List.of(
-        Link.builder().linkType(LinkType.GITHUB).linkUrl("github.com").build(),
-        Link.builder().linkType(LinkType.ETC).linkUrl("test.com").build()
-    );
-    var userInfo = UserInfo.builder()
-        .id(1L)
-        .linkJson(objectMapper.writeValueAsString(linkList))
-        .build();
-    var user = User.builder().id(1L).userRole(UserRole.MEMBER).userInfo(userInfo).build();
+    var user = UserBuildUtil.buildUser().build();
     var principalDetails = getPrincipalDetails(user.getId(), user.getUserRole());
     var url = "/v1/user";
     given(userFacade.getUserWithInfo(user.getId())).willReturn(UserInfoDto.from(user));
@@ -610,13 +604,13 @@ class UserControllerTest extends MockMvcDocs {
             .policyType(PolicyType.PRIVACY_POLICY)
             .version("1.0.0")
             .isAgree(true)
-            .updatedAt("2021-08-10T00:00:00.000+00:00")
+            .updatedAt(LocalDateTime.now())
             .build(),
         PolicyAgreementDto.builder()
             .policyType(PolicyType.PRIVACY_POLICY)
             .version("1.0.0")
             .isAgree(true)
-            .updatedAt("2021-08-10T00:00:00.000+00:00")
+            .updatedAt(LocalDateTime.now())
             .build()
     );
     var updatePolicyAgreementRequest = new UpdatePolicyAgreementRequest(policyAgreementDtoList);

--- a/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
+++ b/src/test/java/org/crops/fitserver/util/MockMvcDocs.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openapitools.jackson.nullable.JsonNullableModule;
@@ -50,7 +51,7 @@ public abstract class MockMvcDocs {
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS,
         SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    objectMapper.registerModules(new JsonNullableModule());
+    objectMapper.registerModules(new JsonNullableModule(), new JavaTimeModule());
     return objectMapper;
   }
 }

--- a/src/test/java/org/crops/fitserver/util/ObjectMapperTestConfig.java
+++ b/src/test/java/org/crops/fitserver/util/ObjectMapperTestConfig.java
@@ -3,6 +3,7 @@ package org.crops.fitserver.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -20,7 +21,7 @@ public class ObjectMapperTestConfig {
       builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
       builder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
       builder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-      builder.modules(jsonNullableModule());
+      builder.modules(jsonNullableModule(), new JavaTimeModule());
     };
   }
 

--- a/src/test/java/org/crops/fitserver/util/UserBuildUtil.java
+++ b/src/test/java/org/crops/fitserver/util/UserBuildUtil.java
@@ -1,0 +1,47 @@
+package org.crops.fitserver.util;
+
+import static org.crops.fitserver.global.util.JsonUtil.toJson;
+
+import java.util.List;
+import org.crops.fitserver.domain.region.domain.Region;
+import org.crops.fitserver.domain.skillset.domain.Position;
+import org.crops.fitserver.domain.user.constant.LinkType;
+import org.crops.fitserver.domain.user.constant.UserInfoStatus;
+import org.crops.fitserver.domain.user.domain.Link;
+import org.crops.fitserver.domain.user.domain.User;
+import org.crops.fitserver.domain.user.domain.User.UserBuilder;
+import org.crops.fitserver.domain.user.domain.UserInfo;
+import org.crops.fitserver.domain.user.domain.UserRole;
+
+public class UserBuildUtil {
+
+  public static UserBuilder buildUser() {
+    var linkList = List.of(
+        Link.builder().linkType(LinkType.GITHUB).linkUrl("github.com").build(),
+        Link.builder().linkType(LinkType.ETC).linkUrl("test.com").build()
+    );
+    var userInfo = UserInfo.builder()
+        .id(1L)
+        .portfolioUrl("test.com")
+        .projectCount(1)
+        .activityHour((short) 1)
+        .introduce("test")
+        .isOpenProfile(true)
+        .position(Position.builder().id(1L).build())
+        .region(Region.builder().id(1L).build())
+        .linkJson(toJson(linkList))
+        .status(UserInfoStatus.INCOMPLETE)
+        .build();
+    return User.builder()
+        .id(1L)
+        .userRole(UserRole.MEMBER)
+        .profileImageUrl("test.com")
+        .username("test")
+        .nickname("test")
+        .phoneNumber("010-1234-1234")
+        .isOpenPhoneNum(true)
+        .email("test@gmail.com")
+        .userInfo(userInfo)
+        ;
+  }
+}


### PR DESCRIPTION
## 🥔 작업한 내용
<!-- 작업 내용을 적어주세요. -->
 - authController에 프론트 테스트를 위해 호출만으로 유저를 만들 수 있는 api를 추가했습니다.
- 매칭 관련 로직을 전체적으로 추가했습니다.
- 스킬 관련 버그를 수정했습니다.

## ❗️ PR POINT
<!-- 덧붙이고 싶은 내용이 있다면 -->
 - src/main/java/org/crops/fitserver/domain/matching/constant/Constant.java에 인원수 관리 상수를 추가했는데, 조금 더 좋은 방법이 있다면 알려주세요!
 - 전체적으로 RESTful api인지 확인 부탁드려요
 - Matching 테이블에 대한 네이밍을 바꾸든지 테이블 두개로 분리하려고 합니다. 이 점 참고해주세요
 - Matching 도메인 뿐 아니라 MatchingRoom 도메인 역시 좀 비대한 감이 없지 않아 있습니다. 개선할 점이 있을까요?
 - MatchingProcessor 포함해서 이를 호출하는 MatchingScheduler쪽 이상한 점 있으면 말씀 부탁드립니다.

## 🔒 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요.-->
- resolved: #40
